### PR TITLE
feat: Add SdJwt.Net.Mdoc (ISO 18013-5) package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ The project is hosted under the **OpenWallet Foundation Labs** organization.
 
 ```
 sd-jwt-dotnet/
- src/                   # Library source projects (8 packages)
+ src/                   # Library source projects (9 packages)
     SdJwt.Net/         # Core SD-JWT implementation (RFC 9901)
     SdJwt.Net.Vc/      # Verifiable Credentials
     SdJwt.Net.StatusList/   # Credential lifecycle / revocation
@@ -27,6 +27,7 @@ sd-jwt-dotnet/
     SdJwt.Net.OidFederation/  # Trust management
     SdJwt.Net.PresentationExchange/  # DIF PEX v2.1.1
     SdJwt.Net.HAIP/    # High assurance security levels
+    SdJwt.Net.Mdoc/    # ISO 18013-5 mDL/mdoc support
  tests/                 # xUnit test projects (one per package)
  samples/               # Console demo application (not packaged)
  docs/                  # Developer documentation
@@ -67,6 +68,90 @@ All code must adhere to these standards without exception:
 5. **No weak cryptography** - MD5 and SHA-1 are blocked by the HAIP validator and must never be used.
 6. **Constant-time comparisons** for all security-sensitive operations.
 7. **DCO compliance** - every commit must have a `Signed-off-by:` line (configured via `.githooks`).
+
+## Test-Driven Development (TDD)
+
+This project follows **Test-Driven Development** methodology. All new features and bug fixes must follow the TDD workflow.
+
+### TDD Workflow (Red-Green-Refactor)
+
+1. **RED**: Write a failing test first that defines the expected behavior.
+2. **GREEN**: Write the minimal code necessary to make the test pass.
+3. **REFACTOR**: Improve the code while keeping all tests passing.
+
+### TDD Requirements
+
+- **Tests First**: Never write implementation code without a corresponding failing test.
+- **One Behavior Per Test**: Each test should verify a single behavior or scenario.
+- **Descriptive Names**: Test method names should clearly describe the scenario and expected outcome.
+- **Arrange-Act-Assert (AAA)**: Structure tests with clear separation of setup, execution, and verification.
+- **Edge Cases**: Include tests for boundary conditions, null inputs, and error scenarios.
+- **Coverage Threshold**: Aim for minimum 90% code coverage; critical paths require 100%.
+
+### Test Naming Convention
+
+```
+MethodName_Scenario_ExpectedBehavior
+```
+
+Examples:
+
+```csharp
+[Fact]
+public void Verify_WithExpiredCredential_ReturnsFalse()
+
+[Fact]
+public void Issue_WithValidClaims_CreatesSignedMdoc()
+
+[Theory]
+[InlineData(null)]
+[InlineData("")]
+public void Constructor_WithInvalidInput_ThrowsArgumentException(string? input)
+```
+
+### Test Project Structure
+
+```
+tests/SdJwt.Net.{PackageName}.Tests/
+    {ClassName}Tests.cs         # Unit tests for specific class
+    Integration/                # Integration tests
+    TestFixtures/               # Shared test data and fixtures
+    TestBase.cs                 # Common test infrastructure
+```
+
+### Test Categories
+
+| Category    | Purpose                            | Execution   |
+| ----------- | ---------------------------------- | ----------- |
+| `[Fact]`    | Unit tests for single behaviors    | Every build |
+| `[Theory]`  | Parameterized tests for variations | Every build |
+| Integration | Cross-component tests              | CI pipeline |
+| End-to-End  | Full workflow validation           | CI pipeline |
+
+### Test Dependencies
+
+All test projects use these packages:
+
+- `xunit` - Test framework
+- `FluentAssertions` - Readable assertions
+- `coverlet.collector` - Code coverage
+- `Microsoft.NET.Test.Sdk` - Test runner integration
+
+### Running Tests
+
+```pwsh
+# Run all tests
+dotnet test
+
+# Run tests with coverage
+dotnet test --collect:"XPlat Code Coverage"
+
+# Run specific test project
+dotnet test tests/SdJwt.Net.Mdoc.Tests/
+
+# Run tests matching a filter
+dotnet test --filter "FullyQualifiedName~MdocVerifier"
+```
 
 ## Versioning Model (MinVer + Release Please)
 
@@ -130,8 +215,8 @@ The `ci-validation.yml` pipeline enforces the following **hard gates** (failure 
 | `scripts/verify.*`           | Restore, build, test, formatting, vulnerability scan |
 | Vulnerability scan           | `dotnet list package --vulnerable` must return clean |
 | HAIP algorithm compliance    | No MD5/SHA1 usage in src/                            |
-| All unit tests               | All 8 test suites must pass                          |
-| Package ecosystem validation | All 8 NuGet packages must be produced                |
+| All unit tests               | All 9 test suites must pass                          |
+| Package ecosystem validation | All 9 NuGet packages must be produced                |
 
 ## NuGet Publishing
 
@@ -155,7 +240,7 @@ All shared MSBuild properties live here to avoid duplication across `.csproj` fi
 
 ### Package Relationships
 
-All 8 packages are independent but `SdJwt.Net` is the foundational dependency:
+All 9 packages are independent but `SdJwt.Net` is the foundational dependency:
 
 ```
 SdJwt.Net (Core)
@@ -166,6 +251,7 @@ SdJwt.Net (Core)
         SdJwt.Net.PresentationExchange
    SdJwt.Net.OidFederation
    SdJwt.Net.HAIP
+   SdJwt.Net.Mdoc          # ISO 18013-5 mDL/mdoc support
 ```
 
 ### Test Projects

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ dotnet run
 
 **Enterprise federation, trust management, intelligent credential selection, and high assurance compliance.**
 
+### **ISO Credential Formats**
+
+| Package                                            | Release        | Specification                                              | Status     |
+| -------------------------------------------------- | -------------- | ---------------------------------------------------------- | ---------- |
+| **[SdJwt.Net.Mdoc](src/SdJwt.Net.Mdoc/README.md)** | NuGet (MinVer) | [ISO 18013-5](https://www.iso.org/standard/69084.html) mDL | **Stable** |
+
+**ISO 18013-5 mobile document (mdoc/mDL) support for driver's licenses and government credentials.**
+
 ## Key Features
 
 ### Enterprise Security
@@ -136,6 +144,26 @@ var incomePresentation = applicant.CreateIncomeVerificationPresentation(
 await bank.ProcessLoanApplicationAsync(incomePresentation);
 ```
 
+### Mobile Driving License (ISO 18013-5 mdoc)
+
+```csharp
+// DMV issues mDL, citizen presents at TSA checkpoint
+using SdJwt.Net.Mdoc.Issuer;
+using SdJwt.Net.Mdoc.Namespaces;
+
+var mdl = await new MdocIssuerBuilder()
+    .WithDocType("org.iso.18013.5.1.mDL")
+    .WithIssuerKey(dmvSigningKey)
+    .WithDeviceKey(citizenDeviceKey)
+    .AddMdlElement(MdlDataElement.FamilyName, "Johnson")
+    .AddMdlElement(MdlDataElement.GivenName, "Alice")
+    .AddMdlElement(MdlDataElement.AgeOver21, true)
+    .BuildAsync(cryptoProvider);
+
+// Citizen presents only age verification (not birthdate)
+await checkpoint.VerifyAgeOnlyAsync(mdl, selectElements: ["age_over_21"]);
+```
+
 ## Architecture Overview
 
 ```mermaid
@@ -162,6 +190,7 @@ graph TB
         Core[SdJwt.Net: RFC 9901]
         Vc[SdJwt.Net.Vc: W3C VC]
         Status[SdJwt.Net.StatusList: Revocation]
+        Mdoc[SdJwt.Net.Mdoc: ISO 18013-5]
     end
 
     WalletApp --> OID4VP
@@ -179,10 +208,13 @@ graph TB
     HAIP --> Core
     HAIP --> Vc
     HAIP --> Status
+    HAIP --> Mdoc
     OidFed --> Core
+    OID4VP --> Mdoc
 
     style HAIP fill:#d62828,color:#fff
     style Core fill:#1b4332,color:#fff
+    style Mdoc fill:#2a6478,color:#fff
 ```
 
 ## Quick Examples
@@ -321,6 +353,7 @@ The CI `performance-benchmarks` job executes the same harness and uploads result
 - [Status Lists](src/SdJwt.Net.StatusList/README.md) - Credential lifecycle management
 - [OpenID4VCI](src/SdJwt.Net.Oid4Vci/README.md) - Credential issuance protocols
 - [OpenID4VP](src/SdJwt.Net.Oid4Vp/README.md) - Presentation protocols
+- [mdoc/mDL](src/SdJwt.Net.Mdoc/README.md) - ISO 18013-5 mobile documents
 
 ### **Advanced Features**
 
@@ -356,6 +389,9 @@ dotnet add package SdJwt.Net.Oid4Vp
 dotnet add package SdJwt.Net.OidFederation
 dotnet add package SdJwt.Net.PresentationExchange
 dotnet add package SdJwt.Net.HAIP
+
+# ISO credential formats
+dotnet add package SdJwt.Net.Mdoc
 ```
 
 ### **Try Comprehensive Examples**

--- a/docs/concepts/mdoc-deep-dive.md
+++ b/docs/concepts/mdoc-deep-dive.md
@@ -1,0 +1,605 @@
+# mdoc Deep Dive (ISO 18013-5)
+
+This document explains mdoc fundamentals in beginner-friendly terms and maps each concept to the implementation in this repository.
+
+## Prerequisites
+
+Before diving into mdoc, you should understand these foundational concepts:
+
+### What is CBOR?
+
+**CBOR (Concise Binary Object Representation)** is a binary data format similar to JSON but more compact. It is defined in RFC 8949 and used extensively in IoT, mobile credentials, and constrained environments.
+
+```text
+JSON: {"name": "Alice", "age": 30}     (29 bytes)
+CBOR: A2 64 6E 61 6D 65 65 41 6C 69 63 65 63 61 67 65 18 1E  (18 bytes)
+```
+
+Key differences from JSON:
+
+- Binary format (not human-readable)
+- Supports more data types (byte strings, tags, undefined)
+- More compact, faster to parse
+- Used by ISO 18013-5 for all mdoc structures
+
+### What is COSE?
+
+**COSE (CBOR Object Signing and Encryption)** is to CBOR what JOSE/JWS is to JSON. It provides cryptographic operations (signing, encryption, MAC) for CBOR data structures. Defined in RFC 8152.
+
+| JOSE/JWT                  | COSE/mdoc    |
+| ------------------------- | ------------ |
+| JWS (JSON Web Signature)  | COSE_Sign1   |
+| JWK (JSON Web Key)        | COSE_Key     |
+| JWE (JSON Web Encryption) | COSE_Encrypt |
+
+### The Problem mdoc Solves
+
+Traditional digital identity systems have several challenges:
+
+1. **Size**: JSON + Base64 encoding is verbose for mobile/NFC
+2. **Offline**: Must work without network connectivity
+3. **Privacy**: Credentials often over-disclose information
+4. **Proximity**: Need secure face-to-face verification
+
+mdoc (mobile document) addresses all these with a compact, privacy-preserving, offline-capable credential format optimized for mobile devices.
+
+## Why mdoc Exists
+
+The ISO 18013-5 standard was developed to enable mobile driving licenses (mDL) - a digital equivalent of the physical driving license stored on a smartphone.
+
+### Key Use Cases
+
+- **TSA checkpoints**: Present mDL via NFC to reader
+- **Traffic stops**: Officer verifies license via Bluetooth
+- **Age verification**: Prove over 21 without revealing birthdate
+- **Car rental**: Present license with selective disclosure
+- **International travel**: Cross-border identity verification
+
+### Comparison with SD-JWT VC
+
+| Feature              | SD-JWT VC     | mdoc            |
+| -------------------- | ------------- | --------------- |
+| Format               | JSON + Base64 | CBOR (binary)   |
+| Size                 | Larger        | Compact         |
+| Offline              | Limited       | Full support    |
+| NFC/BLE              | Complex       | Native design   |
+| Selective Disclosure | At issuance   | At presentation |
+| Standard             | IETF RFC 9901 | ISO 18013-5     |
+| HAIP                 | Supported     | Supported       |
+
+Both formats are supported by OpenID4VP and OpenID4VCI, making them complementary.
+
+## Glossary of Key Terms
+
+| Term                   | Definition                                                     |
+| ---------------------- | -------------------------------------------------------------- |
+| **mdoc**               | Mobile document - the credential format defined by ISO 18013-5 |
+| **mDL**                | Mobile Driving License - the primary use case for mdoc         |
+| **MSO**                | Mobile Security Object - contains digests of all claims        |
+| **IssuerSigned**       | Issuer-generated portion of the credential                     |
+| **DeviceSigned**       | Holder-generated data during presentation                      |
+| **NameSpace**          | Logical grouping of data elements (claims)                     |
+| **DocType**            | Unique identifier for credential type                          |
+| **COSE_Sign1**         | Single-signer COSE signature structure                         |
+| **COSE_Key**           | CBOR-encoded cryptographic key                                 |
+| **Device Engagement**  | Protocol for establishing device connection                    |
+| **Session Transcript** | CBOR binding between request and response                      |
+
+## mdoc Artifact Structure
+
+### Visual Overview
+
+An mdoc document has this hierarchical structure:
+
+```text
+Document
+  DocType: "org.iso.18013.5.1.mDL"
+  IssuerSigned
+     NameSpaces: Map<string, Array<IssuerSignedItem>>
+        "org.iso.18013.5.1"
+           IssuerSignedItem { digestID, random, elementIdentifier, elementValue }
+           IssuerSignedItem { digestID, random, elementIdentifier, elementValue }
+           ...
+     IssuerAuth: COSE_Sign1
+        protected: { alg: ES256 }
+        payload: MobileSecurityObject
+        signature: bytes
+  DeviceSigned (optional, for presentations)
+     NameSpaces: DeviceNameSpaces
+     DeviceAuth: DeviceAuthentication
+```
+
+### Mobile Security Object (MSO)
+
+The MSO is the heart of mdoc security. It contains:
+
+```text
+MobileSecurityObject
+  version: "1.0"
+  digestAlgorithm: "SHA-256"
+  docType: "org.iso.18013.5.1.mDL"
+  valueDigests: Map<namespace, Map<digestID, digest>>
+     "org.iso.18013.5.1"
+        0: SHA256(IssuerSignedItem[0])
+        1: SHA256(IssuerSignedItem[1])
+        ...
+  deviceKeyInfo
+     deviceKey: COSE_Key (holder's public key)
+  validityInfo
+     signed: datetime
+     validFrom: datetime
+     validUntil: datetime
+```
+
+The MSO is signed by the issuer. This signature covers the **digests** of all data elements, not the values themselves - enabling selective disclosure at presentation time.
+
+### Namespace Structure
+
+Data elements are organized into namespaces:
+
+| Namespace                 | DocType                 | Description            |
+| ------------------------- | ----------------------- | ---------------------- |
+| `org.iso.18013.5.1`       | `org.iso.18013.5.1.mDL` | Standard mDL elements  |
+| `org.iso.18013.5.1.aamva` | `org.iso.18013.5.1.mDL` | US AAMVA extensions    |
+| `gov.national.id.1`       | `gov.national.id.1`     | National ID example    |
+| Custom namespace          | Custom DocType          | Enterprise credentials |
+
+## How mdoc Selective Disclosure Works
+
+### Architectural Difference from SD-JWT
+
+**SD-JWT**: Selective disclosure is decided at **issuance time**. The issuer creates disclosures, and the holder chooses which to reveal.
+
+**mdoc**: Selective disclosure happens at **presentation time**. All data elements are issued, but the holder chooses which namespaces and elements to include in the DeviceResponse.
+
+### Step-by-Step Example
+
+#### 1. Issuance: All Data Elements Included
+
+```csharp
+var mdoc = await new MdocIssuerBuilder()
+    .WithDocType("org.iso.18013.5.1.mDL")
+    .WithIssuerKey(issuerKey)
+    .WithDeviceKey(deviceKey)
+    // ALL these elements are included
+    .AddMdlElement(MdlDataElement.FamilyName, "Johnson")
+    .AddMdlElement(MdlDataElement.GivenName, "Alice")
+    .AddMdlElement(MdlDataElement.BirthDate, "1995-07-22")
+    .AddMdlElement(MdlDataElement.DocumentNumber, "D1234567")
+    .AddMdlElement(MdlDataElement.AgeOver21, true)
+    .AddMdlElement(MdlDataElement.ResidentAddress, "123 Main St")
+    .BuildAsync(cryptoProvider);
+```
+
+#### 2. MSO Contains All Digests
+
+The MSO includes digests for every data element:
+
+```text
+valueDigests:
+  "org.iso.18013.5.1":
+    0: SHA256(family_name item) = "abc123..."
+    1: SHA256(given_name item) = "def456..."
+    2: SHA256(birth_date item) = "ghi789..."
+    3: SHA256(document_number item) = "jkl012..."
+    4: SHA256(age_over_21 item) = "mno345..."
+    5: SHA256(resident_address item) = "pqr678..."
+```
+
+#### 3. Presentation: Holder Selects Elements
+
+For age verification, holder only includes `age_over_21`:
+
+```csharp
+// Holder creates selective presentation
+var presentation = new Document
+{
+    DocType = mdoc.DocType,
+    IssuerSigned = new IssuerSigned
+    {
+        NameSpaces = new Dictionary<string, List<IssuerSignedItem>>
+        {
+            ["org.iso.18013.5.1"] = new()
+            {
+                // Only include age_over_21
+                mdoc.IssuerSigned.NameSpaces["org.iso.18013.5.1"]
+                    .First(i => i.ElementIdentifier == "age_over_21")
+            }
+        },
+        IssuerAuth = mdoc.IssuerSigned.IssuerAuth // Same signature!
+    }
+};
+```
+
+#### 4. Verification: Digest Matching
+
+The verifier:
+
+1. Extracts MSO from IssuerAuth
+2. Verifies issuer signature over MSO
+3. For each presented IssuerSignedItem:
+   - Computes `SHA256(item.ToCbor())`
+   - Checks digest exists in MSO's valueDigests
+4. Validates the MSO's deviceKey matches (if DeviceSigned present)
+
+```csharp
+var verifier = new MdocVerifier();
+var result = verifier.Verify(presentation, new MdocVerificationOptions
+{
+    ExpectedDocType = "org.iso.18013.5.1.mDL",
+    ValidateExpiry = true
+});
+
+// result.VerifiedClaims contains only:
+//   age_over_21: true
+// All other claims are NOT visible to verifier
+```
+
+## End-to-End Lifecycle
+
+### Phase 1: Issuance
+
+The issuer (DMV) creates the mdoc credential:
+
+```csharp
+using System.Security.Cryptography;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Issuer;
+using SdJwt.Net.Mdoc.Namespaces;
+
+public class DmvIssuanceService
+{
+    private readonly ECDsa _issuerKey;
+    private readonly ICoseCryptoProvider _crypto;
+
+    public DmvIssuanceService(ECDsa issuerKey)
+    {
+        _issuerKey = issuerKey;
+        _crypto = new DefaultCoseCryptoProvider();
+    }
+
+    public async Task<byte[]> IssueMdlAsync(
+        DriverApplication application,
+        byte[] devicePublicKeyCbor)
+    {
+        var deviceKey = CoseKey.FromCbor(devicePublicKeyCbor);
+        var issuerKey = CoseKey.FromECDsa(_issuerKey);
+
+        var mdoc = await new MdocIssuerBuilder()
+            .WithDocType(MdlNamespace.DocType)
+            .WithIssuerKey(issuerKey)
+            .WithDeviceKey(deviceKey)
+            .WithAlgorithm(CoseAlgorithm.ES256)
+            // Mandatory elements
+            .AddMdlElement(MdlDataElement.FamilyName, application.FamilyName)
+            .AddMdlElement(MdlDataElement.GivenName, application.GivenName)
+            .AddMdlElement(MdlDataElement.BirthDate, application.BirthDate)
+            .AddMdlElement(MdlDataElement.IssueDate, DateTime.UtcNow.ToString("yyyy-MM-dd"))
+            .AddMdlElement(MdlDataElement.ExpiryDate, DateTime.UtcNow.AddYears(5).ToString("yyyy-MM-dd"))
+            .AddMdlElement(MdlDataElement.IssuingCountry, "US")
+            .AddMdlElement(MdlDataElement.IssuingAuthority, "State DMV")
+            .AddMdlElement(MdlDataElement.DocumentNumber, application.DocumentNumber)
+            // Age verification flags (computed from birthdate)
+            .AddMdlElement(MdlDataElement.AgeOver18, application.IsOver18)
+            .AddMdlElement(MdlDataElement.AgeOver21, application.IsOver21)
+            // Optional
+            .AddMdlElement(MdlDataElement.Portrait, application.Photo)
+            .AddMdlElement(MdlDataElement.DrivingPrivileges, application.Privileges)
+            .WithValidity(
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(_crypto);
+
+        return mdoc.ToCbor();
+    }
+}
+```
+
+### Phase 2: Holder Presentation via OpenID4VP
+
+```csharp
+using SdJwt.Net.Mdoc.Handover;
+using SdJwt.Net.Mdoc.Models;
+
+public class WalletPresentationService
+{
+    public byte[] CreatePresentation(
+        Document mdoc,
+        string[] requestedElements,
+        string verifierClientId,
+        string nonce,
+        string responseUri)
+    {
+        // Create session transcript for OID4VP binding
+        var transcript = SessionTranscript.ForOpenId4Vp(
+            clientId: verifierClientId,
+            nonce: nonce,
+            mdocGeneratedNonce: null,
+            responseUri: responseUri);
+
+        // Filter to only requested elements
+        var filteredNamespaces = new Dictionary<string, List<IssuerSignedItem>>();
+        foreach (var ns in mdoc.IssuerSigned.NameSpaces)
+        {
+            var filtered = ns.Value
+                .Where(item => requestedElements.Contains(item.ElementIdentifier))
+                .ToList();
+
+            if (filtered.Any())
+                filteredNamespaces[ns.Key] = filtered;
+        }
+
+        // Create selective document
+        var presentation = new Document
+        {
+            DocType = mdoc.DocType,
+            IssuerSigned = new IssuerSigned
+            {
+                NameSpaces = filteredNamespaces,
+                IssuerAuth = mdoc.IssuerSigned.IssuerAuth
+            }
+        };
+
+        // Wrap in DeviceResponse
+        var response = new DeviceResponse
+        {
+            Version = "1.0",
+            Documents = new List<Document> { presentation },
+            Status = 0
+        };
+
+        return response.ToCbor();
+    }
+}
+```
+
+### Phase 3: Verifier Validation
+
+```csharp
+using SdJwt.Net.Mdoc.Verifier;
+
+public class VerifierService
+{
+    private readonly MdocVerifier _verifier = new();
+
+    public VerificationResult VerifyPresentation(
+        byte[] presentationBytes,
+        string expectedDocType,
+        string[] requiredElements)
+    {
+        // Parse device response
+        var response = DeviceResponse.FromCbor(presentationBytes);
+
+        if (response.Status != 0)
+            return VerificationResult.Failed($"Device error: {response.Status}");
+
+        foreach (var doc in response.Documents)
+        {
+            // Verify each document
+            var options = new MdocVerificationOptions
+            {
+                ValidateExpiry = true,
+                ExpectedDocType = expectedDocType,
+                RequiredElements = requiredElements
+            };
+
+            var result = _verifier.Verify(doc, options);
+
+            if (!result.IsValid)
+                return VerificationResult.Failed(result.Error);
+
+            // Access verified claims
+            foreach (var claim in result.VerifiedClaims)
+            {
+                Console.WriteLine($"Verified: {claim.Key} = {claim.Value}");
+            }
+        }
+
+        return VerificationResult.Success();
+    }
+}
+```
+
+## Session Transcript and Handover
+
+### Why Session Binding Matters
+
+Without session binding, an attacker could:
+
+1. Intercept a valid mdoc presentation
+2. Replay it to another verifier
+3. Impersonate the legitimate holder
+
+Session transcript binds the presentation to:
+
+- The specific verifier (audience)
+- The specific session (nonce)
+- The specific response URI
+
+### OpenID4VP Handover Types
+
+#### 1. Redirect Flow (Same-Device or Cross-Device)
+
+```csharp
+var transcript = SessionTranscript.ForOpenId4Vp(
+    clientId: "https://verifier.example.com",
+    nonce: "session-unique-nonce",
+    mdocGeneratedNonce: null,  // Optional device nonce
+    responseUri: "https://verifier.example.com/callback");
+```
+
+The handover OID4VPHandover is:
+
+```text
+[
+  clientId,        // "https://verifier.example.com"
+  responseUri,     // "https://verifier.example.com/callback"
+  nonce,           // "session-unique-nonce"
+  mdocNonce        // null or device-generated
+]
+```
+
+#### 2. DC API Flow (Browser-Based)
+
+```csharp
+var transcript = SessionTranscript.ForOpenId4VpDcApi(
+    origin: "https://verifier.example.com",
+    nonce: "browser-session-nonce",
+    clientId: null);  // Defaults to origin
+```
+
+The handover OID4VPDcApiHandover is:
+
+```text
+[
+  "OID4VPDCAPIHandover",  // Fixed tag
+  origin,                  // "https://verifier.example.com"
+  SHA256(nonce)           // Hash of nonce
+]
+```
+
+### Session Transcript Structure
+
+```text
+SessionTranscript = [
+  DeviceEngagementBytes,  // null for OID4VP
+  EReaderKeyBytes,        // null for OID4VP
+  Handover                // OID4VPHandover or OID4VPDCAPIHandover
+]
+```
+
+## COSE Cryptography
+
+### Supported Algorithms
+
+| Algorithm | COSE ID | Curve | Security Level |
+| --------- | ------- | ----- | -------------- |
+| ES256     | -7      | P-256 | HAIP Level 1   |
+| ES384     | -35     | P-384 | HAIP Level 2   |
+| ES512     | -36     | P-521 | HAIP Level 3   |
+
+### COSE_Key Structure
+
+```csharp
+var key = new CoseKey
+{
+    KeyType = CoseKeyTypes.Ec2,  // 2 = EC2
+    Curve = CoseCurves.P256,     // 1 = P-256
+    X = xCoordinate,              // 32 bytes
+    Y = yCoordinate,              // 32 bytes
+    D = privateKey                // 32 bytes (optional, private only)
+};
+
+// Serialize
+byte[] keyCbor = key.ToCbor();
+
+// Deserialize
+var restored = CoseKey.FromCbor(keyCbor);
+```
+
+### COSE_Sign1 Structure
+
+```text
+COSE_Sign1 = [
+  protected: bstr,   // CBOR-encoded { alg: -7 }
+  unprotected: {},   // Empty map
+  payload: bstr,     // MSO bytes
+  signature: bstr    // ECDSA signature
+]
+```
+
+## Implementation Guide
+
+### Package Structure
+
+```text
+SdJwt.Net.Mdoc/
+  Cbor/
+     ICborSerializable.cs     # Interface for CBOR serialization
+     CborUtils.cs             # Helper methods
+  Cose/
+     CoseAlgorithm.cs         # ES256, ES384, ES512
+     CoseKey.cs               # Key representation
+     CoseSign1.cs             # Signature structure
+     ICoseCryptoProvider.cs   # Abstraction for crypto
+     DefaultCoseCryptoProvider.cs  # Default implementation
+  Models/
+     MobileSecurityObject.cs  # MSO structure
+     ValidityInfo.cs          # Validity timestamps
+     DigestIdMapping.cs       # Digest mappings
+     IssuerSigned.cs          # Issuer data
+     Document.cs              # Complete mdoc
+     DeviceResponse.cs        # Presentation response
+  Issuer/
+     MdocIssuer.cs            # Core issuance
+     MdocIssuerBuilder.cs     # Fluent API
+     MdocIssuerOptions.cs     # Configuration
+  Verifier/
+     MdocVerifier.cs          # Verification
+     MdocVerificationOptions.cs
+     MdocVerificationResult.cs
+  Handover/
+     SessionTranscript.cs     # Session binding
+     OpenId4VpHandover.cs     # Redirect flow
+     OpenId4VpDcApiHandover.cs  # DC API flow
+  Namespaces/
+     MdlDataElement.cs        # mDL element enum
+     MdlNamespace.cs          # mDL namespace constants
+```
+
+### Key Classes
+
+| Class               | Purpose                            |
+| ------------------- | ---------------------------------- |
+| `MdocIssuerBuilder` | Fluent API for credential creation |
+| `MdocVerifier`      | Verification of mdoc presentations |
+| `CoseKey`           | COSE key operations                |
+| `SessionTranscript` | Session binding for OID4VP         |
+| `Document`          | Complete mdoc credential           |
+| `DeviceResponse`    | Presentation response container    |
+
+## Security Considerations
+
+### Cryptographic Requirements
+
+1. **Algorithm Strength**: Only HAIP-approved algorithms (ES256+)
+2. **Digest Algorithm**: SHA-256, SHA-384, or SHA-512 only
+3. **No MD5/SHA-1**: Blocked by HAIP validator
+
+### Replay Attack Prevention
+
+```csharp
+// Verifier generates unique nonce per request
+var nonce = GenerateCryptographicNonce();
+
+// Include nonce in authorization request
+var request = new AuthorizationRequest
+{
+    Nonce = nonce,
+    // ...
+};
+
+// Verify nonce in response
+if (transcript.Nonce != expectedNonce)
+    throw new SecurityException("Nonce mismatch - possible replay attack");
+```
+
+### Device Binding
+
+The device key in MSO ensures only the legitimate holder can present:
+
+```text
+MSO.deviceKeyInfo.deviceKey = holder's public key
+
+// During presentation, holder proves possession by:
+// 1. Creating DeviceSigned with signature using device private key
+// 2. Or through session transcript binding in OID4VP
+```
+
+## Related Resources
+
+- [Hello mdoc Tutorial](../tutorials/beginner/05-hello-mdoc.md) - Getting started
+- [mdoc Issuance Tutorial](../tutorials/intermediate/06-mdoc-issuance.md) - Credential creation
+- [mdoc OpenID4VP Integration](../tutorials/advanced/05-mdoc-integration.md) - Presentation flows
+- [mdoc Identity Verification Use Case](../use-cases/mdoc-identity-verification.md) - Real-world scenarios
+- [ISO 18013-5 Specification](https://www.iso.org/standard/69084.html) - Official standard

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -12,6 +12,7 @@ Start with these beginner tutorials to understand core SD-JWT concepts:
 2. [Selective Disclosure](beginner/02-selective-disclosure.md) - Hide and reveal claims (10 min)
 3. [Holder Binding](beginner/03-holder-binding.md) - Cryptographic proof of ownership (10 min)
 4. [Verification Flow](beginner/04-verification-flow.md) - Complete issuer-holder-verifier cycle (15 min)
+5. [Hello mdoc](beginner/05-hello-mdoc.md) - Create your first ISO 18013-5 credential (10 min)
 
 ### Week 2: Standards
 
@@ -22,6 +23,7 @@ Build production skills with protocol tutorials:
 3. [OpenID4VCI](intermediate/03-openid4vci.md) - Credential issuance protocol (20 min)
 4. [OpenID4VP](intermediate/04-openid4vp.md) - Presentation protocol (20 min)
 5. [Presentation Exchange](intermediate/05-presentation-exchange.md) - DIF query language (15 min)
+6. [mdoc Issuance](intermediate/06-mdoc-issuance.md) - Complete mdoc credential flows (20 min)
 
 ### Week 3: Production
 
@@ -31,6 +33,7 @@ Advanced tutorials for enterprise deployment:
 2. [HAIP Compliance](advanced/02-haip-compliance.md) - Security levels 1-3 (15 min)
 3. [Multi-Credential Flow](advanced/03-multi-credential-flow.md) - Combined presentations (20 min)
 4. [Key Rotation](advanced/04-key-rotation.md) - Operational security (15 min)
+5. [mdoc OpenID4VP Integration](advanced/05-mdoc-integration.md) - mdoc presentation flows (25 min)
 
 ## Running the Samples
 

--- a/docs/tutorials/advanced/05-mdoc-integration.md
+++ b/docs/tutorials/advanced/05-mdoc-integration.md
@@ -1,0 +1,414 @@
+# Tutorial: mdoc OpenID4VP Integration
+
+Build complete mdoc presentation flows with OpenID4VP for production verification.
+
+**Time:** 25 minutes  
+**Level:** Advanced  
+**Sample:** `samples/SdJwt.Net.Samples/03-Advanced/05-MdocIntegration.cs`
+
+## What You Will Learn
+
+- How to integrate mdoc with OpenID4VP presentation requests
+- How to create session transcripts for different flows
+- How to verify mdoc presentations
+- How to combine mdoc with SD-JWT VC in multi-credential scenarios
+
+## Prerequisites
+
+- Completed [mdoc Issuance](../intermediate/06-mdoc-issuance.md)
+- Completed [OpenID4VP](../intermediate/04-openid4vp.md)
+- Understanding of presentation protocols
+
+## OpenID4VP mdoc Flow Overview
+
+```mermaid
+sequenceDiagram
+    participant Wallet as Wallet (Holder)
+    participant Verifier as Verifier (RP)
+    participant Issuer as Issuer (DMV)
+
+    Note over Wallet,Issuer: Credential Issuance (prior)
+    Issuer->>Wallet: mdoc credential (CBOR)
+
+    Note over Wallet,Verifier: Presentation Flow
+    Verifier->>Wallet: OpenID4VP Request (mso_mdoc format)
+    Wallet->>Wallet: Select claims to disclose
+    Wallet->>Wallet: Create DeviceResponse with SessionTranscript
+    Wallet->>Verifier: OpenID4VP Response (DeviceResponse CBOR)
+    Verifier->>Verifier: Verify signature, claims, session binding
+```
+
+## Session Transcripts
+
+### OpenID4VP Redirect Flow
+
+```csharp
+using SdJwt.Net.Mdoc.Handover;
+
+// Standard redirect-based flow (same-device or cross-device)
+var transcript = SessionTranscript.ForOpenId4Vp(
+    clientId: "https://verifier.example.com",
+    nonce: "xyz789-nonce",
+    mdocGeneratedNonce: null, // Optional device nonce
+    responseUri: "https://verifier.example.com/callback");
+
+// Serialize for inclusion in DeviceResponse
+byte[] transcriptCbor = transcript.ToCbor();
+```
+
+### OpenID4VP DC API Flow (Browser)
+
+```csharp
+// W3C Digital Credentials API flow (browser-based)
+var dcApiTranscript = SessionTranscript.ForOpenId4VpDcApi(
+    origin: "https://verifier.example.com",
+    nonce: "browser-session-nonce",
+    clientId: null); // Defaults to origin
+```
+
+### Custom Handover Construction
+
+```csharp
+using SdJwt.Net.Mdoc.Handover;
+
+// Manual handover creation for flexibility
+var handover = OpenId4VpHandover.Create(
+    clientId: "https://verifier.example.com",
+    responseUri: "https://verifier.example.com/response",
+    nonce: "verifier-nonce",
+    mdocGeneratedNonce: "wallet-generated-nonce");
+
+var transcript = new SessionTranscript
+{
+    DeviceEngagement = null,  // Not used in OID4VP
+    EReaderKeyPub = null,     // Not used in OID4VP
+    Handover = handover
+};
+```
+
+## Creating DeviceResponse
+
+### Build Presentation Response
+
+```csharp
+using SdJwt.Net.Mdoc.Models;
+
+// Assume we have an issued mdoc
+var document = /* previously issued Document */;
+
+// Create device response for presentation
+var deviceResponse = new DeviceResponse
+{
+    Version = "1.0",
+    Documents = new List<Document> { document },
+    Status = 0 // Success
+};
+
+// Serialize for transmission
+byte[] responseBytes = deviceResponse.ToCbor();
+```
+
+### Selective Disclosure in mdoc
+
+Unlike SD-JWT where disclosures are selective at issuance, mdoc selective disclosure happens at presentation time. The holder creates a DeviceResponse containing only the namespaces and elements they wish to disclose.
+
+```csharp
+// Create response with selected elements only
+// (Implementation depends on your presentation logic)
+var selectiveDocument = new Document
+{
+    DocType = originalDoc.DocType,
+    IssuerSigned = new IssuerSigned
+    {
+        NameSpaces = FilterNamespaces(
+            originalDoc.IssuerSigned.NameSpaces,
+            requestedElements),
+        IssuerAuth = originalDoc.IssuerSigned.IssuerAuth
+    }
+};
+```
+
+## Verifying mdoc Presentations
+
+### Basic Verification
+
+```csharp
+using SdJwt.Net.Mdoc.Verifier;
+
+var verifier = new MdocVerifier();
+
+var options = new MdocVerificationOptions
+{
+    ValidateExpiry = true,
+    ExpectedDocType = "org.iso.18013.5.1.mDL",
+    RequiredNamespace = MdlNamespace.Namespace,
+    RequiredElements = new[]
+    {
+        MdlDataElement.FamilyName.ToElementIdentifier(),
+        MdlDataElement.AgeOver21.ToElementIdentifier()
+    }
+};
+
+var result = verifier.Verify(document, options);
+
+if (result.IsValid)
+{
+    Console.WriteLine("Verification successful");
+
+    // Access verified claims
+    foreach (var claim in result.VerifiedClaims)
+    {
+        Console.WriteLine($"{claim.Key}: {claim.Value}");
+    }
+}
+else
+{
+    Console.WriteLine($"Verification failed: {result.Error}");
+}
+```
+
+### Full Verification Pipeline
+
+```csharp
+public class MdocVerificationService
+{
+    private readonly MdocVerifier _verifier = new();
+
+    public async Task<VerificationOutcome> VerifyPresentationAsync(
+        byte[] presentationBytes,
+        string expectedNonce,
+        string verifierClientId)
+    {
+        // Parse device response
+        var response = DeviceResponse.FromCbor(presentationBytes);
+
+        // Verify response status
+        if (response.Status != 0)
+        {
+            return VerificationOutcome.Failed($"Device error: {response.Status}");
+        }
+
+        var outcomes = new List<DocumentVerification>();
+
+        foreach (var doc in response.Documents)
+        {
+            var options = new MdocVerificationOptions
+            {
+                ValidateExpiry = true,
+                ExpectedDocType = doc.DocType
+            };
+
+            var result = _verifier.Verify(doc, options);
+
+            outcomes.Add(new DocumentVerification
+            {
+                DocType = doc.DocType,
+                IsValid = result.IsValid,
+                Claims = result.VerifiedClaims,
+                Error = result.Error
+            });
+        }
+
+        return new VerificationOutcome
+        {
+            Success = outcomes.All(o => o.IsValid),
+            Documents = outcomes
+        };
+    }
+}
+```
+
+## Multi-Credential Flows
+
+### Combined SD-JWT VC and mdoc
+
+```csharp
+using SdJwt.Net.Oid4Vp;
+using SdJwt.Net.PresentationExchange;
+
+// Create presentation definition requesting both formats
+var presentationDefinition = new PresentationDefinition
+{
+    Id = "multi-credential-request",
+    InputDescriptors = new[]
+    {
+        // SD-JWT VC credential
+        new InputDescriptor
+        {
+            Id = "employment-proof",
+            Format = new Dictionary<string, object>
+            {
+                ["vc+sd-jwt"] = new { alg = new[] { "ES256" } }
+            },
+            Constraints = new Constraints
+            {
+                Fields = new[]
+                {
+                    new Field { Path = new[] { "$.vct" }, Filter = new Filter { Const = "EmploymentCredential" } }
+                }
+            }
+        },
+        // mdoc credential
+        new InputDescriptor
+        {
+            Id = "age-verification",
+            Format = new Dictionary<string, object>
+            {
+                ["mso_mdoc"] = new { alg = new[] { "ES256" } }
+            },
+            Constraints = new Constraints
+            {
+                Fields = new[]
+                {
+                    new Field
+                    {
+                        Path = new[] { "$['org.iso.18013.5.1']['age_over_21']" },
+                        Filter = new Filter { Const = true }
+                    }
+                }
+            }
+        }
+    }
+};
+```
+
+### Processing Multi-Format Response
+
+```csharp
+public class MultiFormatVerifier
+{
+    private readonly VpTokenValidator _sdJwtValidator;
+    private readonly MdocVerifier _mdocVerifier;
+
+    public async Task<CombinedResult> VerifyMultiFormatAsync(
+        AuthorizationResponse response)
+    {
+        var results = new CombinedResult();
+
+        foreach (var vpToken in response.VpTokens)
+        {
+            if (vpToken.Format == "vc+sd-jwt")
+            {
+                // Verify SD-JWT VC
+                var sdJwtResult = await _sdJwtValidator.ValidateAsync(
+                    vpToken.Token,
+                    new VpValidationParameters { /* ... */ });
+                results.SdJwtCredentials.Add(sdJwtResult);
+            }
+            else if (vpToken.Format == "mso_mdoc")
+            {
+                // Verify mdoc
+                var mdocBytes = Convert.FromBase64String(vpToken.Token);
+                var document = Document.FromCbor(mdocBytes);
+                var mdocResult = _mdocVerifier.Verify(document, new MdocVerificationOptions());
+                results.MdocCredentials.Add(mdocResult);
+            }
+        }
+
+        return results;
+    }
+}
+```
+
+## HAIP Compliance
+
+### Level 2+ Requirements
+
+```csharp
+using SdJwt.Net.HAIP;
+using SdJwt.Net.Mdoc.Cose;
+
+// HAIP Level 2 requires ES384 or stronger
+var haipValidator = new HaipCryptoValidator(HaipLevel.Level2_VeryHigh);
+
+// Validate mdoc algorithm compliance
+var algorithmCheck = haipValidator.ValidateAlgorithm(CoseAlgorithm.ES384);
+if (!algorithmCheck.IsCompliant)
+{
+    throw new SecurityException("Algorithm does not meet HAIP Level 2 requirements");
+}
+
+// Issue with HAIP-compliant settings
+using var issuerKey = ECDsa.Create(ECCurve.NamedCurves.nistP384); // P-384 for ES384
+
+var mdoc = await new MdocIssuerBuilder()
+    .WithDocType("org.iso.18013.5.1.mDL")
+    .WithIssuerKey(CoseKey.FromECDsa(issuerKey))
+    .WithDeviceKey(deviceKey)
+    .WithAlgorithm(CoseAlgorithm.ES384) // HAIP Level 2 compliant
+    .AddMdlElement(MdlDataElement.FamilyName, "Smith")
+    // ... other elements
+    .BuildAsync(cryptoProvider);
+```
+
+## Complete Integration Example
+
+```csharp
+public class MdocOpenId4VpService
+{
+    private readonly HttpClient _httpClient;
+    private readonly MdocVerifier _verifier;
+
+    public async Task<OpenId4VpOutcome> ProcessMdocPresentationAsync(
+        string authorizationRequestUri,
+        Document holderMdoc,
+        ECDsa devicePrivateKey)
+    {
+        // 1. Fetch and parse authorization request
+        var authRequest = await FetchAuthorizationRequestAsync(authorizationRequestUri);
+
+        // 2. Create session transcript
+        var transcript = SessionTranscript.ForOpenId4Vp(
+            clientId: authRequest.ClientId,
+            nonce: authRequest.Nonce,
+            mdocGeneratedNonce: GenerateNonce(),
+            responseUri: authRequest.ResponseUri);
+
+        // 3. Create device response
+        var deviceResponse = new DeviceResponse
+        {
+            Version = "1.0",
+            Documents = new List<Document> { holderMdoc },
+            Status = 0
+        };
+
+        // 4. Submit response
+        var responseBytes = deviceResponse.ToCbor();
+        var result = await SubmitPresentationAsync(
+            authRequest.ResponseUri,
+            Convert.ToBase64String(responseBytes));
+
+        return result;
+    }
+
+    private string GenerateNonce()
+    {
+        var bytes = new byte[16];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes);
+    }
+}
+```
+
+## Run the Sample
+
+```bash
+cd samples/SdJwt.Net.Samples
+dotnet run -- 3.5
+```
+
+## Next Steps
+
+- [ISO 18013-5 Cross-Border](../../use-cases/mdoc-identity-verification.md) - Real-world scenarios
+- [HAIP Compliance](02-haip-compliance.md) - Security levels for mdoc
+- [mdoc Deep Dive](../../concepts/mdoc-deep-dive.md) - Technical deep dive
+
+## Key Concepts
+
+| Concept           | Description                                   |
+| ----------------- | --------------------------------------------- |
+| SessionTranscript | CBOR binding between request and response     |
+| DeviceResponse    | Holder's presentation response container      |
+| OpenID4VP         | Standard protocol for credential presentation |
+| DC API            | W3C Digital Credentials API for browsers      |
+| Multi-format      | Combining SD-JWT VC and mdoc credentials      |

--- a/docs/tutorials/beginner/05-hello-mdoc.md
+++ b/docs/tutorials/beginner/05-hello-mdoc.md
@@ -1,0 +1,166 @@
+# Tutorial: Hello mdoc
+
+Create your first ISO 18013-5 mobile document credential in 10 minutes.
+
+**Time:** 10 minutes  
+**Level:** Beginner  
+**Sample:** `samples/SdJwt.Net.Samples/01-Beginner/05-HelloMdoc.cs`
+
+## What You Will Learn
+
+- How to create an mdoc issuer
+- How to build and sign a mobile document credential
+- How to understand the CBOR-based document structure
+
+## Prerequisites
+
+- .NET 9.0 SDK installed
+- Basic understanding of digital credentials
+- Completed [Hello SD-JWT](01-hello-sd-jwt.md)
+
+## Step 1: Install the Package
+
+Add the mdoc package to your project:
+
+```bash
+dotnet add package SdJwt.Net.Mdoc
+```
+
+## Step 2: Create Cryptographic Keys
+
+Every mdoc system needs two keys: an issuer key (for signing) and a device key (for holder binding):
+
+```csharp
+using System.Security.Cryptography;
+using SdJwt.Net.Mdoc.Cose;
+
+// Create issuer signing key (P-256 curve - ECDSA)
+using var issuerEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+var issuerKey = CoseKey.FromECDsa(issuerEcdsa);
+
+// Create device key for holder binding
+using var deviceEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+var deviceKey = CoseKey.FromECDsa(deviceEcdsa);
+```
+
+## Step 3: Create the Issuer Builder
+
+Use `MdocIssuerBuilder` for fluent credential construction:
+
+```csharp
+using SdJwt.Net.Mdoc.Issuer;
+
+var builder = new MdocIssuerBuilder()
+    .WithDocType("org.iso.18013.5.1.mDL")
+    .WithIssuerKey(issuerKey)
+    .WithDeviceKey(deviceKey);
+```
+
+## Step 4: Add Data Elements
+
+Add claims using the mDL namespace helpers:
+
+```csharp
+using SdJwt.Net.Mdoc.Namespaces;
+
+builder
+    .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+    .AddMdlElement(MdlDataElement.GivenName, "John")
+    .AddMdlElement(MdlDataElement.BirthDate, "1990-05-15")
+    .AddMdlElement(MdlDataElement.IssueDate, "2024-01-01")
+    .AddMdlElement(MdlDataElement.ExpiryDate, "2029-01-01")
+    .AddMdlElement(MdlDataElement.IssuingCountry, "US")
+    .AddMdlElement(MdlDataElement.IssuingAuthority, "State DMV")
+    .AddMdlElement(MdlDataElement.DocumentNumber, "DL123456789");
+```
+
+## Step 5: Set Validity and Build
+
+```csharp
+using SdJwt.Net.Mdoc.Cose;
+
+var cryptoProvider = new DefaultCoseCryptoProvider();
+
+builder.WithValidity(
+    validFrom: DateTimeOffset.UtcNow,
+    validUntil: DateTimeOffset.UtcNow.AddYears(5));
+
+var mdoc = await builder.BuildAsync(cryptoProvider);
+
+Console.WriteLine($"Created mdoc with DocType: {mdoc.DocType}");
+Console.WriteLine($"Contains {mdoc.IssuerSigned.NameSpaces.Count} namespace(s)");
+```
+
+## Understanding the Output
+
+The resulting `Document` contains:
+
+- **DocType**: The credential type identifier (e.g., `org.iso.18013.5.1.mDL`)
+- **IssuerSigned**: Namespaced data elements with COSE signature
+- **DeviceSigned**: Optional device-generated data (for presentations)
+
+Structure:
+
+```text
+Document
+  DocType: "org.iso.18013.5.1.mDL"
+  IssuerSigned
+     NameSpaces: {"org.iso.18013.5.1": [...items]}
+     IssuerAuth: COSE_Sign1 (contains MSO)
+```
+
+## Complete Example
+
+```csharp
+using System.Security.Cryptography;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Issuer;
+using SdJwt.Net.Mdoc.Namespaces;
+
+// Setup keys
+using var issuerEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+using var deviceEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+var issuerKey = CoseKey.FromECDsa(issuerEcdsa);
+var deviceKey = CoseKey.FromECDsa(deviceEcdsa);
+var cryptoProvider = new DefaultCoseCryptoProvider();
+
+// Build and issue mdoc
+var mdoc = await new MdocIssuerBuilder()
+    .WithDocType("org.iso.18013.5.1.mDL")
+    .WithIssuerKey(issuerKey)
+    .WithDeviceKey(deviceKey)
+    .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+    .AddMdlElement(MdlDataElement.GivenName, "John")
+    .AddMdlElement(MdlDataElement.BirthDate, "1990-05-15")
+    .AddMdlElement(MdlDataElement.DocumentNumber, "DL123456")
+    .WithValidity(
+        DateTimeOffset.UtcNow,
+        DateTimeOffset.UtcNow.AddYears(5))
+    .BuildAsync(cryptoProvider);
+
+Console.WriteLine($"Created mdoc: {mdoc.DocType}");
+```
+
+## Run the Sample
+
+```bash
+cd samples/SdJwt.Net.Samples
+dotnet run -- 1.5
+```
+
+## Next Steps
+
+- [mdoc Issuance](../intermediate/06-mdoc-issuance.md) - Complete credential issuance flows
+- [mdoc Deep Dive](../../concepts/mdoc-deep-dive.md) - Understanding ISO 18013-5
+
+## Key Concepts
+
+| Term       | Description                             |
+| ---------- | --------------------------------------- |
+| mdoc       | Mobile document format per ISO 18013-5  |
+| CBOR       | Concise Binary Object Representation    |
+| COSE       | CBOR Object Signing and Encryption      |
+| MSO        | Mobile Security Object (signed digests) |
+| mDL        | Mobile Driving License                  |
+| Device Key | Holder's key for proof of possession    |

--- a/docs/tutorials/intermediate/06-mdoc-issuance.md
+++ b/docs/tutorials/intermediate/06-mdoc-issuance.md
@@ -1,0 +1,298 @@
+# Tutorial: mdoc Credential Issuance
+
+Build production-ready mdoc credentials with namespaces, validity, and custom claims.
+
+**Time:** 20 minutes  
+**Level:** Intermediate  
+**Sample:** `samples/SdJwt.Net.Samples/02-Intermediate/06-MdocIssuance.cs`
+
+## What You Will Learn
+
+- How to create complete mDL credentials with all required elements
+- How to work with custom namespaces
+- How to handle COSE key operations
+- How to serialize and deserialize mdoc documents
+
+## Prerequisites
+
+- Completed [Hello mdoc](../beginner/05-hello-mdoc.md)
+- Understanding of cryptographic key management
+- Familiarity with JSON/CBOR concepts
+
+## Complete mDL Issuance
+
+### Step 1: Configure the Issuer
+
+```csharp
+using System.Security.Cryptography;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Issuer;
+using SdJwt.Net.Mdoc.Namespaces;
+
+// Production issuance requires proper key management
+using var issuerKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+using var deviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+var cryptoProvider = new DefaultCoseCryptoProvider();
+```
+
+### Step 2: Build Complete mDL
+
+```csharp
+var mdoc = await new MdocIssuerBuilder()
+    .WithDocType(MdlNamespace.DocType) // "org.iso.18013.5.1.mDL"
+    .WithIssuerKey(CoseKey.FromECDsa(issuerKey))
+    .WithDeviceKey(CoseKey.FromECDsa(deviceKey))
+    .WithAlgorithm(CoseAlgorithm.ES256)
+    // Required mDL elements
+    .AddMdlElement(MdlDataElement.FamilyName, "Johnson")
+    .AddMdlElement(MdlDataElement.GivenName, "Alice Marie")
+    .AddMdlElement(MdlDataElement.BirthDate, "1995-07-22")
+    .AddMdlElement(MdlDataElement.IssueDate, "2024-03-01")
+    .AddMdlElement(MdlDataElement.ExpiryDate, "2029-03-01")
+    .AddMdlElement(MdlDataElement.IssuingCountry, "US")
+    .AddMdlElement(MdlDataElement.IssuingAuthority, "California DMV")
+    .AddMdlElement(MdlDataElement.DocumentNumber, "D1234567")
+    .AddMdlElement(MdlDataElement.UnDistinguishingSign, "USA")
+    // Optional personal data
+    .AddMdlElement(MdlDataElement.Sex, "F")
+    .AddMdlElement(MdlDataElement.Height, 165)
+    .AddMdlElement(MdlDataElement.Weight, 58)
+    .AddMdlElement(MdlDataElement.EyeColour, "brown")
+    .AddMdlElement(MdlDataElement.HairColour, "black")
+    // Address
+    .AddMdlElement(MdlDataElement.ResidentAddress, "123 Main Street")
+    .AddMdlElement(MdlDataElement.ResidentCity, "Los Angeles")
+    .AddMdlElement(MdlDataElement.ResidentState, "CA")
+    .AddMdlElement(MdlDataElement.ResidentPostalCode, "90001")
+    .AddMdlElement(MdlDataElement.ResidentCountry, "US")
+    // Age flags (computed from birth date)
+    .AddMdlElement(MdlDataElement.AgeOver18, true)
+    .AddMdlElement(MdlDataElement.AgeOver21, true)
+    // Validity period
+    .WithValidity(
+        DateTimeOffset.UtcNow,
+        DateTimeOffset.UtcNow.AddYears(5))
+    .BuildAsync(cryptoProvider);
+```
+
+## Working with Custom Namespaces
+
+### Adding Custom Claims
+
+For credentials beyond mDL, use generic namespaces:
+
+```csharp
+var credentialDocType = "org.example.employee.badge.1";
+var credentialNamespace = "org.example.employee.1";
+
+var employeeBadge = await new MdocIssuerBuilder()
+    .WithDocType(credentialDocType)
+    .WithIssuerKey(CoseKey.FromECDsa(issuerKey))
+    .WithDeviceKey(CoseKey.FromECDsa(deviceKey))
+    // Custom namespace claims
+    .AddClaim(credentialNamespace, "employee_id", "EMP-2024-001")
+    .AddClaim(credentialNamespace, "full_name", "Alice Johnson")
+    .AddClaim(credentialNamespace, "department", "Engineering")
+    .AddClaim(credentialNamespace, "clearance_level", 3)
+    .AddClaim(credentialNamespace, "building_access", new[] { "HQ", "Lab-A", "Lab-B" })
+    .AddClaim(credentialNamespace, "hire_date", "2020-06-15")
+    // Access control flags
+    .AddClaim(credentialNamespace, "is_manager", true)
+    .AddClaim(credentialNamespace, "remote_access_allowed", true)
+    .WithValidity(
+        DateTimeOffset.UtcNow,
+        DateTimeOffset.UtcNow.AddYears(1))
+    .BuildAsync(cryptoProvider);
+```
+
+### Multiple Namespaces
+
+mdoc credentials can contain multiple namespaces:
+
+```csharp
+var credential = await new MdocIssuerBuilder()
+    .WithDocType("org.example.multi.credential")
+    .WithIssuerKey(CoseKey.FromECDsa(issuerKey))
+    .WithDeviceKey(CoseKey.FromECDsa(deviceKey))
+    // Primary namespace
+    .AddClaim("org.example.identity", "name", "Alice Johnson")
+    .AddClaim("org.example.identity", "birth_date", "1995-07-22")
+    // Employment namespace
+    .AddClaim("org.example.employment", "employer", "TechCorp Inc")
+    .AddClaim("org.example.employment", "position", "Senior Engineer")
+    // Certification namespace
+    .AddClaim("org.example.certs", "iso27001_certified", true)
+    .AddClaim("org.example.certs", "security_clearance", "Secret")
+    .WithValidity(
+        DateTimeOffset.UtcNow,
+        DateTimeOffset.UtcNow.AddYears(2))
+    .BuildAsync(cryptoProvider);
+```
+
+## COSE Key Operations
+
+### Creating Keys from Raw Materials
+
+```csharp
+using SdJwt.Net.Mdoc.Cose;
+
+// From existing ECDsa parameters
+var parameters = ecdsa.ExportParameters(includePrivateParameters: true);
+
+var coseKey = new CoseKey
+{
+    KeyType = CoseKeyTypes.Ec2,
+    Curve = CoseCurves.P256,
+    X = parameters.Q.X!,
+    Y = parameters.Q.Y!,
+    D = parameters.D // Private key component
+};
+
+// Get public key only (for sharing)
+var publicCoseKey = coseKey.GetPublicKey();
+```
+
+### Key Serialization
+
+```csharp
+// Serialize to CBOR bytes
+byte[] keyBytes = coseKey.ToCbor();
+
+// Deserialize from CBOR
+var restoredKey = CoseKey.FromCbor(keyBytes);
+
+// Convert back to .NET ECDsa
+using var restored = restoredKey.ToECDsa();
+```
+
+### Algorithm Selection
+
+```csharp
+// ES256 (P-256) - Broad compatibility, recommended default
+var es256Builder = new MdocIssuerBuilder()
+    .WithAlgorithm(CoseAlgorithm.ES256);
+
+// ES384 (P-384) - Higher security
+var es384Builder = new MdocIssuerBuilder()
+    .WithAlgorithm(CoseAlgorithm.ES384);
+
+// ES512 (P-521) - Maximum security
+var es512Builder = new MdocIssuerBuilder()
+    .WithAlgorithm(CoseAlgorithm.ES512);
+```
+
+## Document Serialization
+
+### Serialize Complete Document
+
+```csharp
+// Serialize document to CBOR
+byte[] documentBytes = mdoc.ToCbor();
+Console.WriteLine($"Document size: {documentBytes.Length} bytes");
+
+// Deserialize document
+using SdJwt.Net.Mdoc.Models;
+var restored = Document.FromCbor(documentBytes);
+```
+
+### Access Document Components
+
+```csharp
+// Get document type
+Console.WriteLine($"DocType: {mdoc.DocType}");
+
+// Access issuer-signed data
+var issuerSigned = mdoc.IssuerSigned;
+
+// List namespaces
+foreach (var ns in issuerSigned.NameSpaces)
+{
+    Console.WriteLine($"Namespace: {ns.Key}");
+    foreach (var item in ns.Value)
+    {
+        Console.WriteLine($"  {item.ElementIdentifier}: {item.ElementValue}");
+    }
+}
+```
+
+## Complete Example: DMV Issuer Service
+
+```csharp
+using System.Security.Cryptography;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Issuer;
+using SdJwt.Net.Mdoc.Namespaces;
+
+public class DmvMdlService
+{
+    private readonly ECDsa _issuerKey;
+    private readonly ICoseCryptoProvider _crypto;
+
+    public DmvMdlService(ECDsa issuerKey)
+    {
+        _issuerKey = issuerKey;
+        _crypto = new DefaultCoseCryptoProvider();
+    }
+
+    public async Task<byte[]> IssueMdlAsync(
+        string familyName,
+        string givenName,
+        DateTime birthDate,
+        string documentNumber,
+        byte[] devicePublicKey)
+    {
+        // Parse device key from wallet
+        var deviceKey = CoseKey.FromCbor(devicePublicKey);
+
+        // Calculate age flags
+        var age = DateTime.UtcNow.Year - birthDate.Year;
+        if (birthDate.Date > DateTime.UtcNow.AddYears(-age)) age--;
+
+        // Issue credential
+        var mdoc = await new MdocIssuerBuilder()
+            .WithDocType(MdlNamespace.DocType)
+            .WithIssuerKey(CoseKey.FromECDsa(_issuerKey))
+            .WithDeviceKey(deviceKey)
+            .WithAlgorithm(CoseAlgorithm.ES256)
+            .AddMdlElement(MdlDataElement.FamilyName, familyName)
+            .AddMdlElement(MdlDataElement.GivenName, givenName)
+            .AddMdlElement(MdlDataElement.BirthDate, birthDate.ToString("yyyy-MM-dd"))
+            .AddMdlElement(MdlDataElement.IssueDate, DateTime.UtcNow.ToString("yyyy-MM-dd"))
+            .AddMdlElement(MdlDataElement.ExpiryDate, DateTime.UtcNow.AddYears(5).ToString("yyyy-MM-dd"))
+            .AddMdlElement(MdlDataElement.IssuingCountry, "US")
+            .AddMdlElement(MdlDataElement.IssuingAuthority, "State DMV")
+            .AddMdlElement(MdlDataElement.DocumentNumber, documentNumber)
+            .AddMdlElement(MdlDataElement.AgeOver18, age >= 18)
+            .AddMdlElement(MdlDataElement.AgeOver21, age >= 21)
+            .WithValidity(
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(_crypto);
+
+        return mdoc.ToCbor();
+    }
+}
+```
+
+## Run the Sample
+
+```bash
+cd samples/SdJwt.Net.Samples
+dotnet run -- 2.6
+```
+
+## Next Steps
+
+- [mdoc OpenID4VP Integration](../advanced/05-mdoc-integration.md) - Presentation protocols
+- [OpenID4VCI](03-openid4vci.md) - Credential issuance with mdoc format
+
+## Key Concepts
+
+| Concept        | Description                           |
+| -------------- | ------------------------------------- |
+| Namespace      | Grouping of related claims in mdoc    |
+| DocType        | Unique identifier for credential type |
+| IssuerAuth     | COSE_Sign1 signature over MSO         |
+| Validity       | Signed validity period in MSO         |
+| Device Binding | Holder's public key in credential     |

--- a/docs/use-cases/mdoc-identity-verification.md
+++ b/docs/use-cases/mdoc-identity-verification.md
@@ -1,0 +1,607 @@
+# Mobile Identity Verification with mdoc: From TSA Checkpoints to Cross-Border Travel
+
+> **Quick Facts**
+>
+> |              |                                                                                                                                                                                 |
+> | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+> | Industry     | Government / Travel / Identity Verification                                                                                                                                     |
+> | Complexity   | High                                                                                                                                                                            |
+> | Key Packages | `SdJwt.Net.Mdoc`, `SdJwt.Net.Oid4Vp`, `SdJwt.Net.HAIP`, `SdJwt.Net.PresentationExchange`                                                                                        |
+> | Sample       | [MdocIdentityVerification.cs](https://github.com/openwallet-foundation-labs/sd-jwt-dotnet/tree/main/samples/SdJwt.Net.Samples/04-UseCases/Identity/MdocIdentityVerification.cs) |
+
+## Executive Summary
+
+ISO 18013-5 mobile documents (mdoc) are becoming the global standard for digital identity credentials. From mobile driving licenses (mDL) in the United States to the EU Digital Identity Wallet (EUDIW), governments worldwide are adopting this compact, privacy-preserving credential format for citizen identity.
+
+This creates a practical opportunity: mdoc credentials enable secure, offline-capable identity verification that protects citizen privacy while meeting regulatory requirements. The SD-JWT .NET ecosystem provides a complete implementation of mdoc alongside SD-JWT VC, enabling verifiers to accept both credential formats through unified OpenID4VP flows.
+
+Key capabilities:
+
+- **Offline verification**: CBOR-based format works without network connectivity
+- **Selective disclosure**: Citizens reveal only required attributes (age flag, not birthdate)
+- **Device binding**: Cryptographic proof the credential belongs to the presenter
+- **HAIP compliance**: Meets high assurance requirements for government credentials
+- **Cross-format support**: Same verification flow for mdoc and SD-JWT VC
+
+---
+
+## 1) Why This Matters Now: Digital Identity Infrastructure is Scaling
+
+Digital identity credentials are moving from pilot to production:
+
+**United States**:
+
+- AAMVA (American Association of Motor Vehicle Administrators) has published mDL Implementation Guidelines
+- States including Utah, Colorado, Arizona, Louisiana are issuing production mDLs
+- TSA accepts mDL at participating airports via CAT (Credential Authentication Technology) readers
+- Apple Wallet and Google Wallet support mDL storage
+
+**European Union**:
+
+- eIDAS 2.0 regulation (2024/1183) mandates EUDIW adoption by 2026
+- Architecture Reference Framework (ARF) specifies mdoc as a supported format
+- Large-Scale Pilots (LSPs) testing cross-border credential exchange
+
+**International**:
+
+- ISO 18013-7 defines international verification protocols
+- ICAO exploring mDL linkage with travel documents
+- Australia, Japan, Korea advancing mDL programs
+
+The key implication: identity verifiers need to accept mdoc credentials now, and the verification infrastructure must handle both mdoc and SD-JWT VC formats.
+
+---
+
+## 2) The Architecture Pattern: Unified Multi-Format Verification
+
+### Diagram A: Complete Identity Verification Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Citizen as Citizen/Traveler
+    participant Wallet as Digital Wallet (mDL/EUDIW)
+    participant Verifier as Verifier (TSA/Border/Service)
+    participant Reader as Reader Device
+    participant Trust as Trust Infrastructure
+
+    Note over Citizen,Trust: Credential Already Issued by DMV/Government
+
+    Citizen->>Verifier: Approach checkpoint/service
+    Verifier->>Reader: Initialize verification session
+    Reader->>Wallet: Device Engagement (NFC/QR/BLE)
+    Wallet->>Citizen: Consent prompt (what will be shared)
+    Citizen->>Wallet: Approve selective disclosure
+    Wallet->>Reader: DeviceResponse (selected claims only)
+    Reader->>Reader: Verify MSO signature
+    Reader->>Reader: Match digests for disclosed claims
+    Reader->>Trust: Optional: Check issuer trust/revocation
+    Reader->>Verifier: Verification result + disclosed claims
+    Verifier->>Citizen: Proceed/Deny + audit log
+```
+
+What this architecture enforces:
+
+- Citizen consents before any data leaves the wallet
+- Only selected claims are transmitted (not the full credential)
+- Cryptographic verification works offline (online trust check optional)
+- Audit trail maintains what was verified, not what was disclosed but not requested
+
+### Diagram B: Multi-Format Verifier Architecture
+
+```mermaid
+flowchart TB
+    subgraph Presentation["Credential Presentation"]
+        OID4VP["OpenID4VP Request"]
+        PEX["Presentation Definition (PEX)"]
+    end
+
+    subgraph Formats["Credential Formats"]
+        SDJWT["SD-JWT VC (vc+sd-jwt)"]
+        MDOC["mdoc (mso_mdoc)"]
+    end
+
+    subgraph Verification["Unified Verification"]
+        Router["Format Router"]
+        SDVerifier["SdVerifier"]
+        MdocVerifier["MdocVerifier"]
+        TrustResolver["Trust Chain Resolver"]
+    end
+
+    subgraph Result["Verification Outcome"]
+        Claims["Verified Claims"]
+        Audit["Audit Receipt"]
+        Decision["Authorization Decision"]
+    end
+
+    OID4VP --> PEX
+    PEX --> SDJWT
+    PEX --> MDOC
+    SDJWT --> Router
+    MDOC --> Router
+    Router --> SDVerifier
+    Router --> MdocVerifier
+    SDVerifier --> TrustResolver
+    MdocVerifier --> TrustResolver
+    TrustResolver --> Claims
+    Claims --> Audit
+    Audit --> Decision
+```
+
+Scope note: The SD-JWT .NET ecosystem provides the format-specific verifiers (SdVerifier, MdocVerifier), presentation exchange evaluation, OpenID4VP protocol handling, and HAIP compliance validation. Application-layer components (consent UI, audit storage, device engagement) are implementation-specific.
+
+---
+
+## 3) End-to-End Example: TSA Airport Checkpoint
+
+This is a realistic US scenario: a traveler uses their state-issued mDL at a TSA checkpoint.
+
+### 1. Traveler Approaches Checkpoint
+
+The TSA officer instructs the traveler to present identification. The checkpoint has a CAT reader with both camera and NFC capability.
+
+### 2. Device Engagement
+
+The traveler taps their phone on the NFC reader, or the wallet displays a QR code scanned by the reader:
+
+```csharp
+using SdJwt.Net.Mdoc.Handover;
+
+// Reader initiates session
+var sessionId = Guid.NewGuid().ToString();
+var nonce = GenerateCryptographicNonce();
+
+// For same-device flow (QR displayed on reader screen)
+var authorizationRequest = new AuthorizationRequest
+{
+    ClientId = "https://tsa.gov/checkpoint/SEA-01",
+    ResponseUri = $"https://tsa.gov/verify/{sessionId}",
+    Nonce = nonce,
+    PresentationDefinition = CreateMdlVerificationRequest()
+};
+```
+
+### 3. Presentation Definition (What TSA Requests)
+
+```csharp
+using SdJwt.Net.PresentationExchange;
+
+var presentationDefinition = new PresentationDefinition
+{
+    Id = "tsa-identity-verification",
+    Purpose = "Verify identity for TSA checkpoint access",
+    InputDescriptors = new[]
+    {
+        new InputDescriptor
+        {
+            Id = "mdl-identity",
+            Format = new Dictionary<string, object>
+            {
+                ["mso_mdoc"] = new { alg = new[] { "ES256", "ES384" } }
+            },
+            Constraints = new Constraints
+            {
+                LimitDisclosure = "required",
+                Fields = new[]
+                {
+                    // Required: Photo for visual match
+                    new Field
+                    {
+                        Path = new[] { "$['org.iso.18013.5.1']['portrait']" },
+                        IntentToRetain = false
+                    },
+                    // Required: Name
+                    new Field
+                    {
+                        Path = new[] { "$['org.iso.18013.5.1']['family_name']" },
+                        IntentToRetain = false
+                    },
+                    new Field
+                    {
+                        Path = new[] { "$['org.iso.18013.5.1']['given_name']" },
+                        IntentToRetain = false
+                    },
+                    // Required: Document validity
+                    new Field
+                    {
+                        Path = new[] { "$['org.iso.18013.5.1']['expiry_date']" }
+                    }
+                }
+            }
+        }
+    }
+};
+```
+
+### 4. Wallet Creates Selective Presentation
+
+The wallet shows the traveler exactly what will be shared:
+
+- Portrait photo
+- Family name
+- Given name
+- Expiry date
+
+The wallet does NOT include: address, birthdate, document number, driving privileges.
+
+```csharp
+using SdJwt.Net.Mdoc.Models;
+
+// Wallet filters to only requested elements
+var selectedElements = new[] { "portrait", "family_name", "given_name", "expiry_date" };
+
+var presentation = CreateSelectivePresentation(
+    mdoc: travelerMdl,
+    requestedElements: selectedElements);
+
+// Create session transcript for binding
+var transcript = SessionTranscript.ForOpenId4Vp(
+    clientId: authRequest.ClientId,
+    nonce: authRequest.Nonce,
+    mdocGeneratedNonce: GenerateDeviceNonce(),
+    responseUri: authRequest.ResponseUri);
+
+// Package as DeviceResponse
+var deviceResponse = new DeviceResponse
+{
+    Version = "1.0",
+    Documents = new List<Document> { presentation },
+    Status = 0
+};
+```
+
+### 5. Reader Verifies Presentation
+
+```csharp
+using SdJwt.Net.Mdoc.Verifier;
+
+public class TsaVerificationService
+{
+    private readonly MdocVerifier _verifier = new();
+    private readonly ITrustResolver _trustResolver;
+
+    public async Task<VerificationOutcome> VerifyMdlAsync(
+        byte[] presentationBytes,
+        string expectedNonce)
+    {
+        var response = DeviceResponse.FromCbor(presentationBytes);
+
+        if (response.Status != 0)
+            return VerificationOutcome.DeviceError(response.Status);
+
+        foreach (var doc in response.Documents)
+        {
+            // Verify document structure and signature
+            var options = new MdocVerificationOptions
+            {
+                ValidateExpiry = true,
+                ExpectedDocType = "org.iso.18013.5.1.mDL"
+            };
+
+            var result = _verifier.Verify(doc, options);
+
+            if (!result.IsValid)
+                return VerificationOutcome.Failed(result.Error);
+
+            // Optional: Check issuer against trusted issuers
+            var issuerValid = await _trustResolver.ValidateIssuerAsync(
+                doc.IssuerSigned.IssuerAuth);
+
+            if (!issuerValid)
+                return VerificationOutcome.UntrustedIssuer();
+
+            // Extract verified claims for officer display
+            return VerificationOutcome.Success(result.VerifiedClaims);
+        }
+
+        return VerificationOutcome.NoDocuments();
+    }
+}
+```
+
+### 6. Officer Review and Decision
+
+The CAT reader displays:
+
+- Verified photo (officer compares to traveler)
+- Name: "Alice Johnson"
+- Status: "Credential Valid"
+- Expiry: "2029-03-01"
+
+The officer visually matches the photo, confirms the name, and allows the traveler to proceed.
+
+---
+
+## 4) Cross-Border Scenario: EUDIW at Border Control
+
+This scenario demonstrates mdoc verification at an EU border crossing.
+
+### Architecture for Cross-Border
+
+```mermaid
+flowchart TB
+    subgraph MS_A["Member State A (Issuer)"]
+        Issuer["National ID Authority"]
+        TrustList_A["Trust List MS-A"]
+    end
+
+    subgraph Traveler["EU Citizen"]
+        EUDIW["EUDIW App"]
+        PID["mdoc: Person ID"]
+        MDL["mdoc: mDL"]
+    end
+
+    subgraph MS_B["Member State B (Verifier)"]
+        Border["Border Control"]
+        TrustList_B["Trust List MS-B"]
+        EUTrust["EU Trust Infrastructure"]
+    end
+
+    Issuer -->|Issues| PID
+    Issuer -->|Issues| MDL
+    Issuer -->|Registers| TrustList_A
+    TrustList_A -->|Federated| EUTrust
+    EUTrust -->|Available to| TrustList_B
+
+    EUDIW --> PID
+    EUDIW --> MDL
+
+    Border -->|Requests| EUDIW
+    EUDIW -->|Presents| Border
+    Border -->|Validates via| TrustList_B
+```
+
+### Implementation
+
+```csharp
+public class EuBorderVerificationService
+{
+    private readonly MdocVerifier _mdocVerifier = new();
+    private readonly IEuTrustListClient _trustList;
+
+    public async Task<BorderCheckResult> VerifyTravelerAsync(
+        DeviceResponse response,
+        string expectedNonce)
+    {
+        var results = new List<DocumentVerification>();
+
+        foreach (var doc in response.Documents)
+        {
+            // Verify the document
+            var verifyResult = _mdocVerifier.Verify(doc, new MdocVerificationOptions
+            {
+                ValidateExpiry = true
+            });
+
+            if (!verifyResult.IsValid)
+            {
+                results.Add(DocumentVerification.Failed(doc.DocType, verifyResult.Error));
+                continue;
+            }
+
+            // Validate issuer against EU trust list
+            var issuerCert = ExtractIssuerCertificate(doc.IssuerSigned.IssuerAuth);
+            var trustResult = await _trustList.ValidateIssuerAsync(
+                issuerCert,
+                doc.DocType);
+
+            if (!trustResult.IsTrusted)
+            {
+                results.Add(DocumentVerification.UntrustedIssuer(doc.DocType));
+                continue;
+            }
+
+            results.Add(DocumentVerification.Success(
+                doc.DocType,
+                verifyResult.VerifiedClaims,
+                trustResult.IssuerCountry));
+        }
+
+        return new BorderCheckResult
+        {
+            AllValid = results.All(r => r.IsValid),
+            Documents = results,
+            Timestamp = DateTimeOffset.UtcNow,
+            CheckpointId = "FR-CDG-T2-01"
+        };
+    }
+}
+```
+
+---
+
+## 5) Multi-Credential Scenario: Car Rental Service
+
+A car rental company needs to verify:
+
+1. Driver's license (mdoc mDL)
+2. Proof of insurance (SD-JWT VC)
+3. Payment method (SD-JWT VC)
+
+### Unified Presentation Request
+
+```csharp
+var presentationDefinition = new PresentationDefinition
+{
+    Id = "car-rental-verification",
+    Purpose = "Verify driver eligibility for vehicle rental",
+    InputDescriptors = new[]
+    {
+        // mdoc: Driver's License
+        new InputDescriptor
+        {
+            Id = "drivers-license",
+            Format = new Dictionary<string, object>
+            {
+                ["mso_mdoc"] = new { alg = new[] { "ES256" } }
+            },
+            Constraints = new Constraints
+            {
+                Fields = new[]
+                {
+                    new Field { Path = new[] { "$['org.iso.18013.5.1']['family_name']" } },
+                    new Field { Path = new[] { "$['org.iso.18013.5.1']['given_name']" } },
+                    new Field { Path = new[] { "$['org.iso.18013.5.1']['driving_privileges']" } },
+                    new Field { Path = new[] { "$['org.iso.18013.5.1']['age_over_21']" } }
+                }
+            }
+        },
+        // SD-JWT VC: Insurance
+        new InputDescriptor
+        {
+            Id = "insurance-proof",
+            Format = new Dictionary<string, object>
+            {
+                ["vc+sd-jwt"] = new { alg = new[] { "ES256" } }
+            },
+            Constraints = new Constraints
+            {
+                Fields = new[]
+                {
+                    new Field
+                    {
+                        Path = new[] { "$.vct" },
+                        Filter = new Filter { Const = "InsuranceCredential" }
+                    },
+                    new Field { Path = new[] { "$.coverage_type" } },
+                    new Field { Path = new[] { "$.coverage_amount" } }
+                }
+            }
+        }
+    }
+};
+```
+
+### Multi-Format Verification
+
+```csharp
+public class CarRentalVerificationService
+{
+    private readonly MdocVerifier _mdocVerifier = new();
+    private readonly SdVerifier _sdJwtVerifier;
+
+    public async Task<RentalEligibility> VerifyCustomerAsync(
+        VpTokenResponse response)
+    {
+        var eligibility = new RentalEligibility();
+
+        foreach (var vpToken in response.Tokens)
+        {
+            if (vpToken.Format == "mso_mdoc")
+            {
+                // Verify mdoc
+                var mdocBytes = Convert.FromBase64String(vpToken.Token);
+                var doc = Document.FromCbor(mdocBytes);
+                var result = _mdocVerifier.Verify(doc, new MdocVerificationOptions());
+
+                if (result.IsValid)
+                {
+                    eligibility.DriverName = $"{result.VerifiedClaims["given_name"]} {result.VerifiedClaims["family_name"]}";
+                    eligibility.DrivingPrivileges = result.VerifiedClaims["driving_privileges"];
+                    eligibility.AgeVerified = (bool)result.VerifiedClaims["age_over_21"];
+                }
+            }
+            else if (vpToken.Format == "vc+sd-jwt")
+            {
+                // Verify SD-JWT VC
+                var sdResult = await _sdJwtVerifier.VerifyAsync(
+                    vpToken.Token,
+                    _validationParams);
+
+                if (sdResult.IsValid)
+                {
+                    var claims = sdResult.ClaimsPrincipal.Claims;
+                    eligibility.InsuranceCoverage = claims
+                        .FirstOrDefault(c => c.Type == "coverage_type")?.Value;
+                }
+            }
+        }
+
+        eligibility.IsEligible =
+            eligibility.AgeVerified &&
+            eligibility.DrivingPrivileges != null &&
+            eligibility.InsuranceCoverage != null;
+
+        return eligibility;
+    }
+}
+```
+
+---
+
+## 6) What Success Looks Like (Measurable Outcomes)
+
+A credible identity verification deployment is measured by operational metrics:
+
+| Metric               | Target                    | Measurement                |
+| -------------------- | ------------------------- | -------------------------- |
+| Verification time    | < 3 seconds offline       | Reader device timing       |
+| Privacy compliance   | 100% selective disclosure | Audit log analysis         |
+| False rejection rate | < 0.1%                    | Valid credentials rejected |
+| Device compatibility | 95%+ wallet support       | Interoperability testing   |
+| Trust validation     | 100% issuer checks        | Trust list coverage        |
+
+Key outcomes:
+
+- Reduced manual document inspection time
+- Eliminated photocopying of physical documents
+- Improved citizen privacy (no over-disclosure)
+- Cryptographic audit trail for compliance
+- Interoperability across issuers and verifiers
+
+---
+
+## 7) Developer Implementation Checklist
+
+- [ ] Define presentation requirements per use case (PEX input descriptors)
+- [ ] Implement format routing for mdoc and SD-JWT VC
+- [ ] Configure trust resolver for accepted issuers
+- [ ] Implement consent UI showing exactly what will be disclosed
+- [ ] Store verification audit receipts (claims verified, not values)
+- [ ] Test offline verification (no network latency in critical path)
+- [ ] Validate HAIP compliance (ES256+ algorithms only)
+- [ ] Handle DeviceResponse error codes gracefully
+- [ ] Implement session timeout and nonce expiry
+
+---
+
+## Closing
+
+Mobile identity credentials are transforming how citizens interact with government services, travel infrastructure, and commercial verification. The mdoc format (ISO 18013-5) provides a compact, privacy-preserving, offline-capable credential that is being adopted globally.
+
+The SD-JWT .NET ecosystem provides production-ready mdoc support alongside SD-JWT VC, enabling verifiers to accept both formats through unified OpenID4VP flows. This dual-format capability is essential as different jurisdictions and use cases adopt different credential formats.
+
+For enterprises building identity verification systems: mdoc is not a future technology. States are issuing mDLs today, airlines are accepting them, and the EU is mandating EUDIW support. The time to implement is now.
+
+---
+
+## Related Use Cases
+
+| Use Case                                         | Relationship                     |
+| ------------------------------------------------ | -------------------------------- |
+| [Cross-Border Government](crossborder.md)        | Foundation - EU OOTS integration |
+| [Financial AI](financial-ai.md)                  | Complementary - KYC verification |
+| [Retail E-Commerce](retail-ecommerce-returns.md) | Application - age verification   |
+
+---
+
+## Public References
+
+Standards and Specifications
+
+- ISO 18013-5:2021 Mobile driving licence (mDL): <https://www.iso.org/standard/69084.html>
+- OpenID4VP specification: <https://openid.net/specs/openid-4-verifiable-presentations-1_0.html>
+- OpenID4VC HAIP: <https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html>
+
+Government Programs
+
+- AAMVA mDL Implementation Guidelines: <https://www.aamva.org/mDL/>
+- EU Digital Identity Wallet ARF: <https://digital-strategy.ec.europa.eu/en/library/european-digital-identity-wallet-architecture-and-reference-framework>
+- TSA CAT Verification: <https://www.tsa.gov/travel/frequently-asked-questions/does-tsa-accept-mobile-drivers-licenses-mdls>
+
+Industry
+
+- Apple Wallet mDL: <https://support.apple.com/en-us/HT212940>
+- Google Wallet Digital ID: <https://support.google.com/wallet/answer/12059089>
+
+_Disclaimer: This article is informational and not legal advice. For regulated deployments, validate obligations with your legal/compliance teams and the latest official guidance._

--- a/src/SdJwt.Net.Mdoc/Cbor/CborUtils.cs
+++ b/src/SdJwt.Net.Mdoc/Cbor/CborUtils.cs
@@ -1,0 +1,204 @@
+using PeterO.Cbor;
+
+namespace SdJwt.Net.Mdoc.Cbor;
+
+/// <summary>
+/// CBOR serialization utilities for mdoc-specific structures.
+/// </summary>
+public static class CborUtils
+{
+    /// <summary>
+    /// Serializes a string to CBOR bytes.
+    /// </summary>
+    /// <param name="value">The string to serialize.</param>
+    /// <returns>The CBOR-encoded bytes.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when value is null.</exception>
+    public static byte[] SerializeString(string value)
+    {
+        if (value == null) throw new ArgumentNullException(nameof(value));
+        return CBORObject.FromObject(value).EncodeToBytes();
+    }
+
+    /// <summary>
+    /// Serializes a byte array to CBOR bytes.
+    /// </summary>
+    /// <param name="value">The byte array to serialize.</param>
+    /// <returns>The CBOR-encoded bytes.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when value is null.</exception>
+    public static byte[] SerializeBytes(byte[] value)
+    {
+        if (value == null) throw new ArgumentNullException(nameof(value));
+        return CBORObject.FromObject(value).EncodeToBytes();
+    }
+
+    /// <summary>
+    /// Serializes an integer to CBOR bytes.
+    /// </summary>
+    /// <param name="value">The integer to serialize.</param>
+    /// <returns>The CBOR-encoded bytes.</returns>
+    public static byte[] SerializeInt(int value)
+    {
+        return CBORObject.FromObject(value).EncodeToBytes();
+    }
+
+    /// <summary>
+    /// Serializes a boolean to CBOR bytes.
+    /// </summary>
+    /// <param name="value">The boolean to serialize.</param>
+    /// <returns>The CBOR-encoded bytes.</returns>
+    public static byte[] SerializeBool(bool value)
+    {
+        return CBORObject.FromObject(value).EncodeToBytes();
+    }
+
+    /// <summary>
+    /// Serializes a DateTimeOffset to CBOR bytes with tag 0 (date/time string).
+    /// </summary>
+    /// <param name="value">The DateTimeOffset to serialize.</param>
+    /// <returns>The CBOR-encoded bytes.</returns>
+    public static byte[] SerializeDateTimeOffset(DateTimeOffset value)
+    {
+        // ISO 8601 format per CBOR tag 0
+        var dateString = value.ToString("yyyy-MM-ddTHH:mm:ssZ");
+        return CBORObject.FromObjectAndTag(dateString, 0).EncodeToBytes();
+    }
+
+    /// <summary>
+    /// Deserializes CBOR bytes to a string.
+    /// </summary>
+    /// <param name="cborData">The CBOR-encoded bytes.</param>
+    /// <returns>The deserialized string.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when cborData is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when cborData is empty.</exception>
+    public static string DeserializeString(byte[] cborData)
+    {
+        if (cborData == null) throw new ArgumentNullException(nameof(cborData));
+        if (cborData.Length == 0)
+        {
+            throw new ArgumentException("CBOR data cannot be empty.", nameof(cborData));
+        }
+
+        var cbor = CBORObject.DecodeFromBytes(cborData);
+        return cbor.AsString();
+    }
+
+    /// <summary>
+    /// Deserializes CBOR bytes to a byte array.
+    /// </summary>
+    /// <param name="cborData">The CBOR-encoded bytes.</param>
+    /// <returns>The deserialized byte array.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when cborData is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when cborData is empty.</exception>
+    public static byte[] DeserializeBytes(byte[] cborData)
+    {
+        if (cborData == null) throw new ArgumentNullException(nameof(cborData));
+        if (cborData.Length == 0)
+        {
+            throw new ArgumentException("CBOR data cannot be empty.", nameof(cborData));
+        }
+
+        var cbor = CBORObject.DecodeFromBytes(cborData);
+        return cbor.GetByteString();
+    }
+
+    /// <summary>
+    /// Deserializes CBOR bytes to an integer.
+    /// </summary>
+    /// <param name="cborData">The CBOR-encoded bytes.</param>
+    /// <returns>The deserialized integer.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when cborData is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when cborData is empty.</exception>
+    public static int DeserializeInt(byte[] cborData)
+    {
+        if (cborData == null) throw new ArgumentNullException(nameof(cborData));
+        if (cborData.Length == 0)
+        {
+            throw new ArgumentException("CBOR data cannot be empty.", nameof(cborData));
+        }
+
+        var cbor = CBORObject.DecodeFromBytes(cborData);
+        return cbor.AsInt32();
+    }
+
+    /// <summary>
+    /// Deserializes CBOR bytes to a boolean.
+    /// </summary>
+    /// <param name="cborData">The CBOR-encoded bytes.</param>
+    /// <returns>The deserialized boolean.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when cborData is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when cborData is empty.</exception>
+    public static bool DeserializeBool(byte[] cborData)
+    {
+        if (cborData == null) throw new ArgumentNullException(nameof(cborData));
+        if (cborData.Length == 0)
+        {
+            throw new ArgumentException("CBOR data cannot be empty.", nameof(cborData));
+        }
+
+        var cbor = CBORObject.DecodeFromBytes(cborData);
+        return cbor.AsBoolean();
+    }
+
+    /// <summary>
+    /// Deserializes CBOR bytes to a DateTimeOffset.
+    /// </summary>
+    /// <param name="cborData">The CBOR-encoded bytes.</param>
+    /// <returns>The deserialized DateTimeOffset.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when cborData is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when cborData is empty.</exception>
+    public static DateTimeOffset DeserializeDateTimeOffset(byte[] cborData)
+    {
+        if (cborData == null) throw new ArgumentNullException(nameof(cborData));
+        if (cborData.Length == 0)
+        {
+            throw new ArgumentException("CBOR data cannot be empty.", nameof(cborData));
+        }
+
+        var cbor = CBORObject.DecodeFromBytes(cborData);
+        var dateString = cbor.AsString();
+        return DateTimeOffset.Parse(dateString);
+    }
+
+    /// <summary>
+    /// Deserializes CBOR bytes to the specified ICborSerializable type.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize to.</typeparam>
+    /// <param name="cborData">The CBOR-encoded bytes.</param>
+    /// <returns>The deserialized object.</returns>
+    public static T Deserialize<T>(byte[] cborData) where T : ICborSerializable, new()
+    {
+        if (cborData == null) throw new ArgumentNullException(nameof(cborData));
+        if (cborData.Length == 0)
+        {
+            throw new ArgumentException("CBOR data cannot be empty.", nameof(cborData));
+        }
+
+        // For complex types, create a new instance and populate from CBOR
+        var cbor = CBORObject.DecodeFromBytes(cborData);
+        return FromCborObject<T>(cbor);
+    }
+
+    /// <summary>
+    /// Creates an instance of T from a CBORObject.
+    /// </summary>
+    /// <typeparam name="T">The type to create.</typeparam>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>The created instance.</returns>
+    internal static T FromCborObject<T>(CBORObject cbor) where T : ICborSerializable, new()
+    {
+        // This is a placeholder - actual implementation depends on T
+        return new T();
+    }
+
+    /// <summary>
+    /// Serializes an object to CBOR bytes using tagged encoding.
+    /// </summary>
+    /// <typeparam name="T">The type of object to serialize.</typeparam>
+    /// <param name="value">The object to serialize.</param>
+    /// <returns>The CBOR-encoded bytes.</returns>
+    public static byte[] Serialize<T>(T value) where T : ICborSerializable
+    {
+        if (value == null) throw new ArgumentNullException(nameof(value));
+        return value.ToCbor();
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Cbor/ICborSerializable.cs
+++ b/src/SdJwt.Net.Mdoc/Cbor/ICborSerializable.cs
@@ -1,0 +1,21 @@
+using PeterO.Cbor;
+
+namespace SdJwt.Net.Mdoc.Cbor;
+
+/// <summary>
+/// Interface for types that can be serialized to/from CBOR.
+/// </summary>
+public interface ICborSerializable
+{
+    /// <summary>
+    /// Serializes this object to CBOR bytes.
+    /// </summary>
+    /// <returns>The CBOR-encoded bytes.</returns>
+    byte[] ToCbor();
+
+    /// <summary>
+    /// Gets the CBOR object representation.
+    /// </summary>
+    /// <returns>The CBORObject representation.</returns>
+    CBORObject ToCborObject();
+}

--- a/src/SdJwt.Net.Mdoc/Cose/CoseAlgorithm.cs
+++ b/src/SdJwt.Net.Mdoc/Cose/CoseAlgorithm.cs
@@ -1,0 +1,81 @@
+namespace SdJwt.Net.Mdoc.Cose;
+
+/// <summary>
+/// COSE algorithm identifiers per RFC 8152 and ISO 18013-5.
+/// </summary>
+public enum CoseAlgorithm
+{
+    /// <summary>ECDSA with SHA-256 on P-256 curve.</summary>
+    ES256 = -7,
+
+    /// <summary>ECDSA with SHA-384 on P-384 curve.</summary>
+    ES384 = -35,
+
+    /// <summary>ECDSA with SHA-512 on P-521 curve.</summary>
+    ES512 = -36,
+
+    /// <summary>EdDSA (Ed25519 or Ed448).</summary>
+    EdDSA = -8,
+
+    /// <summary>HMAC with SHA-256.</summary>
+    HMAC256 = 5
+}
+
+/// <summary>
+/// Extension methods for CoseAlgorithm.
+/// </summary>
+public static class CoseAlgorithmExtensions
+{
+    /// <summary>
+    /// Gets the corresponding digest algorithm name for the COSE algorithm.
+    /// </summary>
+    /// <param name="algorithm">The COSE algorithm.</param>
+    /// <returns>The digest algorithm name (e.g., "SHA-256").</returns>
+    public static string GetDigestAlgorithm(this CoseAlgorithm algorithm)
+    {
+        return algorithm switch
+        {
+            CoseAlgorithm.ES256 => "SHA-256",
+            CoseAlgorithm.ES384 => "SHA-384",
+            CoseAlgorithm.ES512 => "SHA-512",
+            CoseAlgorithm.EdDSA => "SHA-512",
+            CoseAlgorithm.HMAC256 => "SHA-256",
+            _ => throw new NotSupportedException($"Algorithm {algorithm} is not supported.")
+        };
+    }
+
+    /// <summary>
+    /// Checks if the algorithm is supported for HAIP compliance.
+    /// </summary>
+    /// <param name="algorithm">The COSE algorithm.</param>
+    /// <returns>True if the algorithm is HAIP-compliant.</returns>
+    public static bool IsSupportedForHaip(this CoseAlgorithm algorithm)
+    {
+        return algorithm switch
+        {
+            CoseAlgorithm.ES256 => true,
+            CoseAlgorithm.ES384 => true,
+            CoseAlgorithm.ES512 => true,
+            CoseAlgorithm.EdDSA => true,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Gets the expected key size in bits for the algorithm.
+    /// </summary>
+    /// <param name="algorithm">The COSE algorithm.</param>
+    /// <returns>The key size in bits.</returns>
+    public static int GetKeySizeBits(this CoseAlgorithm algorithm)
+    {
+        return algorithm switch
+        {
+            CoseAlgorithm.ES256 => 256,
+            CoseAlgorithm.ES384 => 384,
+            CoseAlgorithm.ES512 => 521,
+            CoseAlgorithm.EdDSA => 256,
+            CoseAlgorithm.HMAC256 => 256,
+            _ => throw new NotSupportedException($"Algorithm {algorithm} is not supported.")
+        };
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Cose/CoseKey.cs
+++ b/src/SdJwt.Net.Mdoc/Cose/CoseKey.cs
@@ -1,0 +1,214 @@
+using System.Security.Cryptography;
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Cose;
+
+/// <summary>
+/// COSE_Key representation per RFC 8152.
+/// </summary>
+public class CoseKey : ICborSerializable
+{
+    // COSE_Key parameter labels
+    private const int KeyTypeLabel = 1;
+    private const int AlgorithmLabel = 3;
+    private const int CurveLabel = -1;
+    private const int XCoordinateLabel = -2;
+    private const int YCoordinateLabel = -3;
+    private const int PrivateKeyLabel = -4;
+
+    /// <summary>
+    /// Gets the key type.
+    /// </summary>
+    public CoseKeyType KeyType { get; private set; }
+
+    /// <summary>
+    /// Gets the curve for EC2 keys.
+    /// </summary>
+    public CoseCurve Curve { get; private set; }
+
+    /// <summary>
+    /// Gets the X coordinate for EC2 keys.
+    /// </summary>
+    public byte[] X { get; private set; } = Array.Empty<byte>();
+
+    /// <summary>
+    /// Gets the Y coordinate for EC2 keys.
+    /// </summary>
+    public byte[] Y { get; private set; } = Array.Empty<byte>();
+
+    /// <summary>
+    /// Gets the private key bytes (D parameter) if available.
+    /// </summary>
+    public byte[]? D { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this key contains the private key portion.
+    /// </summary>
+    public bool HasPrivateKey => D != null && D.Length > 0;
+
+    /// <summary>
+    /// Creates a CoseKey from an ECDsa key.
+    /// </summary>
+    /// <param name="ecDsa">The ECDsa key.</param>
+    /// <returns>A new CoseKey instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when ecDsa is null.</exception>
+    public static CoseKey FromECDsa(ECDsa ecDsa)
+    {
+        if (ecDsa == null) throw new ArgumentNullException(nameof(ecDsa));
+
+        var parameters = ecDsa.ExportParameters(includePrivateParameters: true);
+        var curve = GetCoseCurve(parameters.Curve);
+
+        return new CoseKey
+        {
+            KeyType = CoseKeyType.EC2,
+            Curve = curve,
+            X = parameters.Q.X ?? Array.Empty<byte>(),
+            Y = parameters.Q.Y ?? Array.Empty<byte>(),
+            D = parameters.D
+        };
+    }
+
+    /// <summary>
+    /// Creates a CoseKey from CBOR bytes.
+    /// </summary>
+    /// <param name="cborData">The CBOR-encoded key data.</param>
+    /// <returns>A new CoseKey instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when cborData is null.</exception>
+    public static CoseKey FromCbor(byte[] cborData)
+    {
+        if (cborData == null) throw new ArgumentNullException(nameof(cborData));
+
+        var cbor = CBORObject.DecodeFromBytes(cborData);
+        return FromCborObject(cbor);
+    }
+
+    /// <summary>
+    /// Creates a CoseKey from a CBORObject.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new CoseKey instance.</returns>
+    internal static CoseKey FromCborObject(CBORObject cbor)
+    {
+        var key = new CoseKey
+        {
+            KeyType = (CoseKeyType)cbor[KeyTypeLabel].AsInt32()
+        };
+
+        if (key.KeyType == CoseKeyType.EC2)
+        {
+            key.Curve = (CoseCurve)cbor[CurveLabel].AsInt32();
+            key.X = cbor[XCoordinateLabel].GetByteString();
+            key.Y = cbor[YCoordinateLabel].GetByteString();
+
+            if (cbor.ContainsKey(PrivateKeyLabel))
+            {
+                key.D = cbor[PrivateKeyLabel].GetByteString();
+            }
+        }
+
+        return key;
+    }
+
+    /// <summary>
+    /// Gets a copy of this key containing only the public key portion.
+    /// </summary>
+    /// <returns>A new CoseKey with only public key data.</returns>
+    public CoseKey GetPublicKey()
+    {
+        return new CoseKey
+        {
+            KeyType = KeyType,
+            Curve = Curve,
+            X = (byte[])X.Clone(),
+            Y = (byte[])Y.Clone(),
+            D = null
+        };
+    }
+
+    /// <summary>
+    /// Converts this CoseKey to an ECDsa key.
+    /// </summary>
+    /// <returns>A new ECDsa instance.</returns>
+    public ECDsa ToECDsa()
+    {
+        var curve = GetEcCurve(Curve);
+        var ecDsa = ECDsa.Create();
+
+        var parameters = new ECParameters
+        {
+            Curve = curve,
+            Q = new ECPoint
+            {
+                X = X,
+                Y = Y
+            }
+        };
+
+        if (HasPrivateKey)
+        {
+            parameters.D = D;
+        }
+
+        ecDsa.ImportParameters(parameters);
+        return ecDsa;
+    }
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+        cbor.Add(KeyTypeLabel, (int)KeyType);
+        cbor.Add(CurveLabel, (int)Curve);
+        cbor.Add(XCoordinateLabel, X);
+        cbor.Add(YCoordinateLabel, Y);
+
+        if (HasPrivateKey)
+        {
+            cbor.Add(PrivateKeyLabel, D);
+        }
+
+        return cbor;
+    }
+
+    private static CoseCurve GetCoseCurve(ECCurve curve)
+    {
+        if (curve.Oid?.FriendlyName == ECCurve.NamedCurves.nistP256.Oid?.FriendlyName ||
+            curve.Oid?.Value == "1.2.840.10045.3.1.7")
+        {
+            return CoseCurve.P256;
+        }
+
+        if (curve.Oid?.FriendlyName == ECCurve.NamedCurves.nistP384.Oid?.FriendlyName ||
+            curve.Oid?.Value == "1.3.132.0.34")
+        {
+            return CoseCurve.P384;
+        }
+
+        if (curve.Oid?.FriendlyName == ECCurve.NamedCurves.nistP521.Oid?.FriendlyName ||
+            curve.Oid?.Value == "1.3.132.0.35")
+        {
+            return CoseCurve.P521;
+        }
+
+        throw new NotSupportedException($"Curve {curve.Oid?.FriendlyName} is not supported.");
+    }
+
+    private static ECCurve GetEcCurve(CoseCurve curve)
+    {
+        return curve switch
+        {
+            CoseCurve.P256 => ECCurve.NamedCurves.nistP256,
+            CoseCurve.P384 => ECCurve.NamedCurves.nistP384,
+            CoseCurve.P521 => ECCurve.NamedCurves.nistP521,
+            _ => throw new NotSupportedException($"Curve {curve} is not supported.")
+        };
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Cose/CoseKeyTypes.cs
+++ b/src/SdJwt.Net.Mdoc/Cose/CoseKeyTypes.cs
@@ -1,0 +1,43 @@
+namespace SdJwt.Net.Mdoc.Cose;
+
+/// <summary>
+/// COSE key type identifiers per RFC 8152.
+/// </summary>
+public enum CoseKeyType
+{
+    /// <summary>Octet Key Pair (OKP) - Ed25519, X25519.</summary>
+    OKP = 1,
+
+    /// <summary>Elliptic Curve Keys with x,y coordinates - ECDSA.</summary>
+    EC2 = 2,
+
+    /// <summary>Symmetric key.</summary>
+    Symmetric = 4
+}
+
+/// <summary>
+/// COSE curve identifiers per RFC 8152.
+/// </summary>
+public enum CoseCurve
+{
+    /// <summary>NIST P-256 curve.</summary>
+    P256 = 1,
+
+    /// <summary>NIST P-384 curve.</summary>
+    P384 = 2,
+
+    /// <summary>NIST P-521 curve.</summary>
+    P521 = 3,
+
+    /// <summary>X25519 for ECDH.</summary>
+    X25519 = 4,
+
+    /// <summary>X448 for ECDH.</summary>
+    X448 = 5,
+
+    /// <summary>Ed25519 for EdDSA signatures.</summary>
+    Ed25519 = 6,
+
+    /// <summary>Ed448 for EdDSA signatures.</summary>
+    Ed448 = 7
+}

--- a/src/SdJwt.Net.Mdoc/Cose/CoseSign1.cs
+++ b/src/SdJwt.Net.Mdoc/Cose/CoseSign1.cs
@@ -1,0 +1,261 @@
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Cose;
+
+/// <summary>
+/// COSE_Sign1 structure per RFC 8152.
+/// </summary>
+public class CoseSign1 : ICborSerializable
+{
+    private const int CoseSign1Tag = 18;
+    private const string ContextString = "Signature1";
+
+    /// <summary>
+    /// Creates a new empty COSE_Sign1 structure.
+    /// </summary>
+    public CoseSign1()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new COSE_Sign1 structure with algorithm and payload.
+    /// </summary>
+    /// <param name="algorithm">The signing algorithm.</param>
+    /// <param name="payload">The payload to sign.</param>
+    public CoseSign1(CoseAlgorithm algorithm, byte[]? payload)
+    {
+        Algorithm = algorithm;
+        Payload = payload ?? Array.Empty<byte>();
+    }
+
+    /// <summary>
+    /// Gets or sets the protected headers.
+    /// </summary>
+    public byte[] ProtectedHeaders { get; set; } = Array.Empty<byte>();
+
+    /// <summary>
+    /// Gets or sets the unprotected headers (keyed by string for convenience, converted to int on serialization).
+    /// </summary>
+    public Dictionary<string, object> UnprotectedHeaders { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the payload.
+    /// </summary>
+    public byte[]? Payload { get; set; } = Array.Empty<byte>();
+
+    /// <summary>
+    /// Gets or sets the signature.
+    /// </summary>
+    public byte[]? Signature { get; set; } = Array.Empty<byte>();
+
+    /// <summary>
+    /// Gets or sets the algorithm.
+    /// </summary>
+    public CoseAlgorithm Algorithm { get; set; } = CoseAlgorithm.ES256;
+
+    /// <summary>
+    /// Creates a new COSE_Sign1 structure with a signature.
+    /// </summary>
+    /// <param name="payload">The payload to sign.</param>
+    /// <param name="privateKey">The private key for signing.</param>
+    /// <param name="algorithm">The signing algorithm.</param>
+    /// <param name="cryptoProvider">The crypto provider.</param>
+    /// <param name="externalAad">Optional external additional authenticated data.</param>
+    /// <returns>A new CoseSign1 instance.</returns>
+    public static async Task<CoseSign1> CreateAsync(
+        byte[] payload,
+        CoseKey privateKey,
+        CoseAlgorithm algorithm,
+        ICoseCryptoProvider cryptoProvider,
+        byte[]? externalAad = null)
+    {
+        if (payload == null) throw new ArgumentNullException(nameof(payload));
+        if (privateKey == null) throw new ArgumentNullException(nameof(privateKey));
+        if (cryptoProvider == null) throw new ArgumentNullException(nameof(cryptoProvider));
+
+        var coseSign1 = new CoseSign1
+        {
+            Payload = payload,
+            Algorithm = algorithm
+        };
+
+        // Create protected headers with algorithm
+        var protectedCbor = CBORObject.NewMap();
+        protectedCbor.Add(1, (int)algorithm); // alg parameter
+        coseSign1.ProtectedHeaders = protectedCbor.EncodeToBytes();
+
+        // Create Sig_structure for signing
+        var sigStructure = CreateSigStructure(
+            coseSign1.ProtectedHeaders,
+            externalAad ?? Array.Empty<byte>(),
+            payload);
+
+        // Sign
+        coseSign1.Signature = await cryptoProvider.SignAsync(
+            sigStructure,
+            privateKey,
+            algorithm);
+
+        return coseSign1;
+    }
+
+    /// <summary>
+    /// Verifies the signature.
+    /// </summary>
+    /// <param name="publicKey">The public key for verification.</param>
+    /// <param name="cryptoProvider">The crypto provider.</param>
+    /// <param name="externalAad">Optional external additional authenticated data.</param>
+    /// <returns>True if the signature is valid.</returns>
+    public async Task<bool> VerifyAsync(
+        CoseKey publicKey,
+        ICoseCryptoProvider cryptoProvider,
+        byte[]? externalAad = null)
+    {
+        if (publicKey == null) throw new ArgumentNullException(nameof(publicKey));
+        if (cryptoProvider == null) throw new ArgumentNullException(nameof(cryptoProvider));
+
+        var sigStructure = CreateSigStructure(
+            ProtectedHeaders,
+            externalAad ?? Array.Empty<byte>(),
+            Payload ?? Array.Empty<byte>());
+
+        return await cryptoProvider.VerifyAsync(
+            sigStructure,
+            Signature ?? Array.Empty<byte>(),
+            publicKey,
+            Algorithm);
+    }
+
+    /// <summary>
+    /// Creates a CoseSign1 from CBOR bytes.
+    /// </summary>
+    /// <param name="cborData">The CBOR-encoded data.</param>
+    /// <returns>A new CoseSign1 instance.</returns>
+    public static CoseSign1 FromCbor(byte[] cborData)
+    {
+        if (cborData == null) throw new ArgumentNullException(nameof(cborData));
+
+        var cbor = CBORObject.DecodeFromBytes(cborData);
+
+        // Handle tagged or untagged
+        if (cbor.HasMostOuterTag(CoseSign1Tag))
+        {
+            cbor = cbor.UntagOne();
+        }
+
+        var coseSign1 = new CoseSign1
+        {
+            ProtectedHeaders = cbor[0].GetByteString(),
+            Payload = cbor[2].IsNull ? Array.Empty<byte>() : cbor[2].GetByteString(),
+            Signature = cbor[3].GetByteString()
+        };
+
+        // Parse algorithm from protected headers
+        if (coseSign1.ProtectedHeaders.Length > 0)
+        {
+            var protectedCbor = CBORObject.DecodeFromBytes(coseSign1.ProtectedHeaders);
+            if (protectedCbor.ContainsKey(1))
+            {
+                coseSign1.Algorithm = (CoseAlgorithm)protectedCbor[1].AsInt32();
+            }
+        }
+
+        // Parse unprotected headers
+        var unprotected = cbor[1];
+        if (!unprotected.IsNull && unprotected.Type == CBORType.Map)
+        {
+            foreach (var key in unprotected.Keys)
+            {
+                var keyInt = key.AsInt32();
+                var headerName = GetHeaderName(keyInt);
+                if (keyInt == 33) // x5chain
+                {
+                    coseSign1.UnprotectedHeaders[headerName] = unprotected[key].GetByteString();
+                }
+                else
+                {
+                    coseSign1.UnprotectedHeaders[headerName] = unprotected[key];
+                }
+            }
+        }
+
+        return coseSign1;
+    }
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var array = CBORObject.NewArray();
+        array.Add(ProtectedHeaders);
+
+        var unprotectedCbor = CBORObject.NewMap();
+        foreach (var (key, value) in UnprotectedHeaders)
+        {
+            var headerLabel = GetHeaderLabel(key);
+            if (value is byte[] bytes)
+            {
+                unprotectedCbor.Add(headerLabel, bytes);
+            }
+            else
+            {
+                unprotectedCbor.Add(headerLabel, CBORObject.FromObject(value));
+            }
+        }
+        array.Add(unprotectedCbor);
+
+        array.Add(Payload ?? Array.Empty<byte>());
+        array.Add(Signature ?? Array.Empty<byte>());
+
+        return CBORObject.FromObjectAndTag(array, CoseSign1Tag);
+    }
+
+    private static int GetHeaderLabel(string name)
+    {
+        return name switch
+        {
+            "alg" => 1,
+            "crit" => 2,
+            "content_type" or "cty" => 3,
+            "kid" => 4,
+            "x5chain" => 33,
+            _ => throw new NotSupportedException($"Unknown header: {name}")
+        };
+    }
+
+    private static string GetHeaderName(int label)
+    {
+        return label switch
+        {
+            1 => "alg",
+            2 => "crit",
+            3 => "content_type",
+            4 => "kid",
+            33 => "x5chain",
+            _ => $"unknown_{label}"
+        };
+    }
+
+    private static byte[] CreateSigStructure(byte[] protectedHeaders, byte[] externalAad, byte[] payload)
+    {
+        // Sig_structure = [
+        //   context : "Signature1",
+        //   body_protected : empty_or_serialized_map,
+        //   external_aad : bstr,
+        //   payload : bstr
+        // ]
+        var sigStructure = CBORObject.NewArray();
+        sigStructure.Add(ContextString);
+        sigStructure.Add(protectedHeaders);
+        sigStructure.Add(externalAad);
+        sigStructure.Add(payload);
+
+        return sigStructure.EncodeToBytes();
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Cose/DefaultCoseCryptoProvider.cs
+++ b/src/SdJwt.Net.Mdoc/Cose/DefaultCoseCryptoProvider.cs
@@ -1,0 +1,276 @@
+using System.Security.Cryptography;
+using PeterO.Cbor;
+
+namespace SdJwt.Net.Mdoc.Cose;
+
+/// <summary>
+/// Default implementation of ICoseCryptoProvider using .NET cryptographic primitives.
+/// </summary>
+public class DefaultCoseCryptoProvider : ICoseCryptoProvider
+{
+    /// <inheritdoc/>
+    public byte[] Sign(CoseSign1 coseSign1, ECDsa privateKey)
+    {
+        if (coseSign1 == null) throw new ArgumentNullException(nameof(coseSign1));
+        if (privateKey == null) throw new ArgumentNullException(nameof(privateKey));
+
+        // Build protected header
+        var protectedHeader = CBORObject.NewMap();
+        protectedHeader.Add(1, (int)coseSign1.Algorithm); // alg
+        var protectedBytes = protectedHeader.EncodeToBytes();
+
+        // Build Sig_structure: ["Signature1", protected, external_aad, payload]
+        var sigStructure = CBORObject.NewArray();
+        sigStructure.Add("Signature1");
+        sigStructure.Add(protectedBytes);
+        sigStructure.Add(Array.Empty<byte>()); // external_aad
+        sigStructure.Add(coseSign1.Payload ?? Array.Empty<byte>());
+        var toBeSigned = sigStructure.EncodeToBytes();
+
+        // Sign
+        var hashAlgorithm = GetHashAlgorithm(coseSign1.Algorithm);
+        var signature = SignDataP1363(privateKey, toBeSigned, hashAlgorithm);
+
+        // Build COSE_Sign1 structure
+        var result = CBORObject.NewArray();
+        result.Add(protectedBytes);
+
+        // Build unprotected header
+        var unprotected = CBORObject.NewMap();
+        foreach (var (key, value) in coseSign1.UnprotectedHeaders)
+        {
+            if (key == "x5chain" && value is byte[] certBytes)
+            {
+                unprotected.Add(33, certBytes); // x5chain header label is 33
+            }
+        }
+        result.Add(unprotected);
+
+        result.Add(coseSign1.Payload);
+        result.Add(signature);
+
+        return result.EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public bool Verify(CoseSign1 coseSign1, ECDsa publicKey, byte[]? externalAad = null)
+    {
+        if (coseSign1 == null) throw new ArgumentNullException(nameof(coseSign1));
+        if (publicKey == null) throw new ArgumentNullException(nameof(publicKey));
+
+        if (coseSign1.Signature == null || coseSign1.Signature.Length == 0)
+        {
+            return false;
+        }
+
+        // Build protected header
+        var protectedHeader = CBORObject.NewMap();
+        protectedHeader.Add(1, (int)coseSign1.Algorithm);
+        var protectedBytes = protectedHeader.EncodeToBytes();
+
+        // Build Sig_structure
+        var sigStructure = CBORObject.NewArray();
+        sigStructure.Add("Signature1");
+        sigStructure.Add(protectedBytes);
+        sigStructure.Add(externalAad ?? Array.Empty<byte>());
+        sigStructure.Add(coseSign1.Payload ?? Array.Empty<byte>());
+        var toBeSigned = sigStructure.EncodeToBytes();
+
+        var hashAlgorithm = GetHashAlgorithm(coseSign1.Algorithm);
+
+        try
+        {
+            return VerifyDataP1363(publicKey, toBeSigned, coseSign1.Signature, hashAlgorithm);
+        }
+        catch (CryptographicException)
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<byte[]> SignAsync(
+        byte[] payload,
+        CoseKey privateKey,
+        CoseAlgorithm algorithm,
+        byte[]? protectedHeaders = null,
+        byte[]? externalAad = null)
+    {
+        if (payload == null) throw new ArgumentNullException(nameof(payload));
+        if (privateKey == null) throw new ArgumentNullException(nameof(privateKey));
+
+        if (!privateKey.HasPrivateKey)
+        {
+            throw new InvalidOperationException("Private key is required for signing.");
+        }
+
+        using var ecDsa = privateKey.ToECDsa();
+        var hashAlgorithm = GetHashAlgorithm(algorithm);
+
+        var signature = SignDataP1363(ecDsa, payload, hashAlgorithm);
+
+        return Task.FromResult(signature);
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> VerifyAsync(
+        byte[] signatureStructure,
+        byte[] signature,
+        CoseKey publicKey,
+        CoseAlgorithm algorithm)
+    {
+        if (signatureStructure == null) throw new ArgumentNullException(nameof(signatureStructure));
+        if (signature == null) throw new ArgumentNullException(nameof(signature));
+        if (publicKey == null) throw new ArgumentNullException(nameof(publicKey));
+
+        using var ecDsa = publicKey.ToECDsa();
+        var hashAlgorithm = GetHashAlgorithm(algorithm);
+
+        try
+        {
+            var isValid = VerifyDataP1363(ecDsa, signatureStructure, signature, hashAlgorithm);
+            return Task.FromResult(isValid);
+        }
+        catch (CryptographicException)
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<byte[]> MacAsync(
+        byte[] payload,
+        byte[] key,
+        CoseAlgorithm algorithm,
+        byte[]? externalAad = null)
+    {
+        if (payload == null) throw new ArgumentNullException(nameof(payload));
+        if (key == null) throw new ArgumentNullException(nameof(key));
+
+        using var hmac = new HMACSHA256(key);
+        var mac = hmac.ComputeHash(payload);
+
+        return Task.FromResult(mac);
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> VerifyMacAsync(
+        byte[] macStructure,
+        byte[] mac,
+        byte[] key)
+    {
+        if (macStructure == null) throw new ArgumentNullException(nameof(macStructure));
+        if (mac == null) throw new ArgumentNullException(nameof(mac));
+        if (key == null) throw new ArgumentNullException(nameof(key));
+
+        using var hmac = new HMACSHA256(key);
+        var computedMac = hmac.ComputeHash(macStructure);
+
+        // Use constant-time comparison
+        var isValid = CryptographicOperations.FixedTimeEquals(computedMac, mac);
+
+        return Task.FromResult(isValid);
+    }
+
+    private static HashAlgorithmName GetHashAlgorithm(CoseAlgorithm algorithm)
+    {
+        return algorithm switch
+        {
+            CoseAlgorithm.ES256 => HashAlgorithmName.SHA256,
+            CoseAlgorithm.ES384 => HashAlgorithmName.SHA384,
+            CoseAlgorithm.ES512 => HashAlgorithmName.SHA512,
+            _ => throw new NotSupportedException($"Algorithm {algorithm} is not supported.")
+        };
+    }
+
+    private static byte[] SignDataP1363(ECDsa ecdsa, byte[] data, HashAlgorithmName hashAlgorithm)
+    {
+#if NETSTANDARD2_1
+        // netstandard2.1 doesn't support DSASignatureFormat, so we need to convert DER to P1363
+        var derSignature = ecdsa.SignData(data, hashAlgorithm);
+        return ConvertDerToP1363(derSignature, ecdsa.KeySize);
+#else
+        return ecdsa.SignData(data, hashAlgorithm, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+#endif
+    }
+
+    private static bool VerifyDataP1363(ECDsa ecdsa, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm)
+    {
+#if NETSTANDARD2_1
+        // netstandard2.1 doesn't support DSASignatureFormat, so we need to convert P1363 to DER
+        var derSignature = ConvertP1363ToDer(signature);
+        return ecdsa.VerifyData(data, derSignature, hashAlgorithm);
+#else
+        return ecdsa.VerifyData(data, signature, hashAlgorithm, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+#endif
+    }
+
+#if NETSTANDARD2_1
+    private static byte[] ConvertDerToP1363(byte[] derSignature, int keySize)
+    {
+        // DER format: 0x30 [length] 0x02 [r-length] [r] 0x02 [s-length] [s]
+        var componentLength = keySize / 8;
+        var result = new byte[componentLength * 2];
+
+        var offset = 2; // Skip 0x30 and total length
+
+        // Read R
+        if (derSignature[offset] != 0x02) throw new InvalidOperationException("Invalid DER signature");
+        offset++;
+        var rLength = (int)derSignature[offset++];
+        var rStart = offset;
+        if (derSignature[rStart] == 0x00) { rStart++; rLength--; }
+        var rPadding = componentLength - rLength;
+        Array.Copy(derSignature, rStart, result, rPadding, rLength);
+        offset += derSignature[offset - 1] == 0x00 ? rLength + 1 : rLength;
+
+        // Read S
+        if (derSignature[offset] != 0x02) throw new InvalidOperationException("Invalid DER signature");
+        offset++;
+        var sLength = (int)derSignature[offset++];
+        var sStart = offset;
+        if (derSignature[sStart] == 0x00) { sStart++; sLength--; }
+        var sPadding = componentLength - sLength;
+        Array.Copy(derSignature, sStart, result, componentLength + sPadding, sLength);
+
+        return result;
+    }
+
+    private static byte[] ConvertP1363ToDer(byte[] p1363Signature)
+    {
+        var componentLength = p1363Signature.Length / 2;
+
+        // Find actual R length (skip leading zeros)
+        var rStart = 0;
+        while (rStart < componentLength && p1363Signature[rStart] == 0) rStart++;
+        var rLength = componentLength - rStart;
+        var rNeedsPadding = (p1363Signature[rStart] & 0x80) != 0;
+
+        // Find actual S length (skip leading zeros)
+        var sStart = componentLength;
+        while (sStart < p1363Signature.Length && p1363Signature[sStart] == 0) sStart++;
+        var sLength = p1363Signature.Length - sStart;
+        var sNeedsPadding = (p1363Signature[sStart] & 0x80) != 0;
+
+        var totalLength = 2 + rLength + (rNeedsPadding ? 1 : 0) + 2 + sLength + (sNeedsPadding ? 1 : 0);
+        var result = new byte[2 + totalLength];
+        var offset = 0;
+
+        result[offset++] = 0x30;
+        result[offset++] = (byte)totalLength;
+
+        result[offset++] = 0x02;
+        result[offset++] = (byte)(rLength + (rNeedsPadding ? 1 : 0));
+        if (rNeedsPadding) result[offset++] = 0x00;
+        Array.Copy(p1363Signature, rStart, result, offset, rLength);
+        offset += rLength;
+
+        result[offset++] = 0x02;
+        result[offset++] = (byte)(sLength + (sNeedsPadding ? 1 : 0));
+        if (sNeedsPadding) result[offset++] = 0x00;
+        Array.Copy(p1363Signature, sStart, result, offset, sLength);
+
+        return result;
+    }
+#endif
+}

--- a/src/SdJwt.Net.Mdoc/Cose/ICoseCryptoProvider.cs
+++ b/src/SdJwt.Net.Mdoc/Cose/ICoseCryptoProvider.cs
@@ -1,0 +1,82 @@
+using System.Security.Cryptography;
+
+namespace SdJwt.Net.Mdoc.Cose;
+
+/// <summary>
+/// Abstraction for COSE cryptographic operations, enabling platform-specific implementations.
+/// </summary>
+public interface ICoseCryptoProvider
+{
+    /// <summary>
+    /// Signs a CoseSign1 structure.
+    /// </summary>
+    /// <param name="coseSign1">The COSE_Sign1 structure to sign.</param>
+    /// <param name="privateKey">The private key for signing.</param>
+    /// <returns>The complete COSE_Sign1 CBOR bytes.</returns>
+    byte[] Sign(CoseSign1 coseSign1, ECDsa privateKey);
+
+    /// <summary>
+    /// Verifies a CoseSign1 signature.
+    /// </summary>
+    /// <param name="coseSign1">The COSE_Sign1 structure to verify.</param>
+    /// <param name="publicKey">The public key for verification.</param>
+    /// <param name="externalAad">Optional external additional authenticated data.</param>
+    /// <returns>True if the signature is valid; otherwise, false.</returns>
+    bool Verify(CoseSign1 coseSign1, ECDsa publicKey, byte[]? externalAad = null);
+
+    /// <summary>
+    /// Creates a COSE_Sign1 signature.
+    /// </summary>
+    /// <param name="payload">The payload to sign.</param>
+    /// <param name="privateKey">The private key for signing.</param>
+    /// <param name="algorithm">The signing algorithm.</param>
+    /// <param name="protectedHeaders">Optional protected headers.</param>
+    /// <param name="externalAad">Optional external additional authenticated data.</param>
+    /// <returns>The signature bytes.</returns>
+    Task<byte[]> SignAsync(
+        byte[] payload,
+        CoseKey privateKey,
+        CoseAlgorithm algorithm,
+        byte[]? protectedHeaders = null,
+        byte[]? externalAad = null);
+
+    /// <summary>
+    /// Verifies a COSE_Sign1 signature.
+    /// </summary>
+    /// <param name="signatureStructure">The Sig_structure bytes.</param>
+    /// <param name="signature">The signature to verify.</param>
+    /// <param name="publicKey">The public key for verification.</param>
+    /// <param name="algorithm">The signing algorithm.</param>
+    /// <returns>True if the signature is valid; otherwise, false.</returns>
+    Task<bool> VerifyAsync(
+        byte[] signatureStructure,
+        byte[] signature,
+        CoseKey publicKey,
+        CoseAlgorithm algorithm);
+
+    /// <summary>
+    /// Creates a COSE_Mac0 MAC.
+    /// </summary>
+    /// <param name="payload">The payload to MAC.</param>
+    /// <param name="key">The symmetric key.</param>
+    /// <param name="algorithm">The MAC algorithm.</param>
+    /// <param name="externalAad">Optional external additional authenticated data.</param>
+    /// <returns>The MAC bytes.</returns>
+    Task<byte[]> MacAsync(
+        byte[] payload,
+        byte[] key,
+        CoseAlgorithm algorithm,
+        byte[]? externalAad = null);
+
+    /// <summary>
+    /// Verifies a COSE_Mac0 MAC.
+    /// </summary>
+    /// <param name="macStructure">The MAC_structure bytes.</param>
+    /// <param name="mac">The MAC to verify.</param>
+    /// <param name="key">The symmetric key.</param>
+    /// <returns>True if the MAC is valid; otherwise, false.</returns>
+    Task<bool> VerifyMacAsync(
+        byte[] macStructure,
+        byte[] mac,
+        byte[] key);
+}

--- a/src/SdJwt.Net.Mdoc/Handover/OpenId4VpDcApiHandover.cs
+++ b/src/SdJwt.Net.Mdoc/Handover/OpenId4VpDcApiHandover.cs
@@ -1,0 +1,95 @@
+using System.Security.Cryptography;
+using System.Text;
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Handover;
+
+/// <summary>
+/// OpenID4VP handover structure for DC API (Digital Credentials API) flow.
+/// Used for browser-based credential presentations.
+/// </summary>
+public class OpenId4VpDcApiHandover : ICborSerializable
+{
+    /// <summary>
+    /// Origin of the verifier website.
+    /// </summary>
+    public string Origin { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Client ID of the verifier.
+    /// </summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Nonce for freshness.
+    /// </summary>
+    public string Nonce { get; set; } = string.Empty;
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        // BrowserHandover = [
+        //   "openid4vp",
+        //   originHash: bstr (SHA-256 of origin),
+        //   nonce: tstr,
+        //   aud: tstr  ; client_id
+        // ]
+        var originHash = ComputeSha256(Encoding.UTF8.GetBytes(Origin));
+
+        var array = CBORObject.NewArray();
+        array.Add("openid4vp");
+        array.Add(originHash);
+        array.Add(Nonce);
+        array.Add(ClientId);
+
+        return array;
+    }
+
+    private static byte[] ComputeSha256(byte[] data)
+    {
+#if NETSTANDARD2_1
+        using var sha256 = SHA256.Create();
+        return sha256.ComputeHash(data);
+#else
+        return SHA256.HashData(data);
+#endif
+    }
+
+    /// <summary>
+    /// Creates an OpenId4VpDcApiHandover from parameters.
+    /// </summary>
+    /// <param name="origin">The verifier origin.</param>
+    /// <param name="clientId">The client ID.</param>
+    /// <param name="nonce">The nonce.</param>
+    /// <returns>A new OpenId4VpDcApiHandover instance.</returns>
+    public static OpenId4VpDcApiHandover Create(string origin, string clientId, string nonce)
+    {
+        return new OpenId4VpDcApiHandover
+        {
+            Origin = origin,
+            ClientId = clientId,
+            Nonce = nonce
+        };
+    }
+
+    /// <summary>
+    /// Creates a SessionTranscript with this handover.
+    /// </summary>
+    /// <returns>A SessionTranscript for DC API flow.</returns>
+    public SessionTranscript CreateSessionTranscript()
+    {
+        return new SessionTranscript
+        {
+            DeviceEngagement = null,
+            EReaderKeyPub = null,
+            Handover = this
+        };
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Handover/OpenId4VpHandover.cs
+++ b/src/SdJwt.Net.Mdoc/Handover/OpenId4VpHandover.cs
@@ -1,0 +1,107 @@
+using System.Security.Cryptography;
+using System.Text;
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Handover;
+
+/// <summary>
+/// OpenID4VP handover structure for redirect flow per OID4VP spec.
+/// Used as part of SessionTranscript for device authentication.
+/// </summary>
+public class OpenId4VpHandover : ICborSerializable
+{
+    /// <summary>
+    /// Client ID of the verifier.
+    /// </summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Response URI where the response should be sent.
+    /// </summary>
+    public string ResponseUri { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Nonce for freshness.
+    /// </summary>
+    public string Nonce { get; set; } = string.Empty;
+
+    /// <summary>
+    /// mdoc generated nonce for binding.
+    /// </summary>
+    public string MdocGeneratedNonce { get; set; } = string.Empty;
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        // OID4VPHandover = [
+        //   clientIdHash: bstr,
+        //   responseUriHash: bstr,
+        //   nonce: tstr
+        // ]
+        var clientIdHash = ComputeSha256(ClientId, MdocGeneratedNonce);
+        var responseUriHash = ComputeSha256(ResponseUri, MdocGeneratedNonce);
+
+        var array = CBORObject.NewArray();
+        array.Add(clientIdHash);
+        array.Add(responseUriHash);
+        array.Add(Nonce);
+
+        return array;
+    }
+
+    /// <summary>
+    /// Creates an OpenId4VpHandover from parameters.
+    /// </summary>
+    /// <param name="clientId">The client ID.</param>
+    /// <param name="responseUri">The response URI.</param>
+    /// <param name="nonce">The nonce.</param>
+    /// <param name="mdocGeneratedNonce">The mdoc generated nonce.</param>
+    /// <returns>A new OpenId4VpHandover instance.</returns>
+    public static OpenId4VpHandover Create(
+        string clientId,
+        string responseUri,
+        string nonce,
+        string mdocGeneratedNonce)
+    {
+        return new OpenId4VpHandover
+        {
+            ClientId = clientId,
+            ResponseUri = responseUri,
+            Nonce = nonce,
+            MdocGeneratedNonce = mdocGeneratedNonce
+        };
+    }
+
+    /// <summary>
+    /// Creates a SessionTranscript with this handover.
+    /// </summary>
+    /// <returns>A SessionTranscript for OpenID4VP.</returns>
+    public SessionTranscript CreateSessionTranscript()
+    {
+        return new SessionTranscript
+        {
+            DeviceEngagement = null,
+            EReaderKeyPub = null,
+            Handover = this
+        };
+    }
+
+    private static byte[] ComputeSha256(string value, string mdocGeneratedNonce)
+    {
+        // Hash = SHA-256(value || mdoc_generated_nonce)
+        var combined = Encoding.UTF8.GetBytes(value + mdocGeneratedNonce);
+#if NETSTANDARD2_1
+        using var sha256 = SHA256.Create();
+        return sha256.ComputeHash(combined);
+#else
+        return SHA256.HashData(combined);
+#endif
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Handover/SessionTranscript.cs
+++ b/src/SdJwt.Net.Mdoc/Handover/SessionTranscript.cs
@@ -1,0 +1,154 @@
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Handover;
+
+/// <summary>
+/// Session transcript for mdoc authentication.
+/// Contains device engagement, reader key, and handover data.
+/// </summary>
+public class SessionTranscript : ICborSerializable
+{
+    /// <summary>
+    /// Device engagement data (null for OpenID4VP).
+    /// </summary>
+    public byte[]? DeviceEngagement { get; set; }
+
+    /// <summary>
+    /// Reader key (EReaderKey.Pub) - null for OpenID4VP.
+    /// </summary>
+    public byte[]? EReaderKeyPub { get; set; }
+
+    /// <summary>
+    /// Handover structure (OID4VPHandover, BrowserHandover, etc.).
+    /// </summary>
+    public ICborSerializable? Handover { get; set; }
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var array = CBORObject.NewArray();
+
+        // DeviceEngagementBytes (null for OpenID4VP)
+        if (DeviceEngagement != null)
+        {
+            array.Add(CBORObject.FromObjectAndTag(DeviceEngagement, 24));
+        }
+        else
+        {
+            array.Add(CBORObject.Null);
+        }
+
+        // EReaderKeyBytes (null for OpenID4VP)
+        if (EReaderKeyPub != null)
+        {
+            array.Add(CBORObject.FromObjectAndTag(EReaderKeyPub, 24));
+        }
+        else
+        {
+            array.Add(CBORObject.Null);
+        }
+
+        // Handover
+        if (Handover != null)
+        {
+            array.Add(Handover.ToCborObject());
+        }
+        else
+        {
+            array.Add(CBORObject.Null);
+        }
+
+        return array;
+    }
+
+    /// <summary>
+    /// Creates a SessionTranscript from CBOR bytes.
+    /// </summary>
+    /// <param name="cbor">The CBOR bytes.</param>
+    /// <returns>A new SessionTranscript instance.</returns>
+    public static SessionTranscript FromCbor(byte[] cbor)
+    {
+        return FromCborObject(CBORObject.DecodeFromBytes(cbor));
+    }
+
+    /// <summary>
+    /// Creates a SessionTranscript from a CBOR object.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new SessionTranscript instance.</returns>
+    public static SessionTranscript FromCborObject(CBORObject cbor)
+    {
+        var transcript = new SessionTranscript();
+
+        if (cbor.Count > 0 && !cbor[0].IsNull)
+        {
+            var devEngCbor = cbor[0];
+            transcript.DeviceEngagement = devEngCbor.HasMostOuterTag(24)
+                ? devEngCbor.GetByteString()
+                : devEngCbor.EncodeToBytes();
+        }
+
+        if (cbor.Count > 1 && !cbor[1].IsNull)
+        {
+            var readerKeyCbor = cbor[1];
+            transcript.EReaderKeyPub = readerKeyCbor.HasMostOuterTag(24)
+                ? readerKeyCbor.GetByteString()
+                : readerKeyCbor.EncodeToBytes();
+        }
+
+        // Note: Handover deserialization requires knowing the type
+
+        return transcript;
+    }
+
+    /// <summary>
+    /// Creates a SessionTranscript for OpenID4VP redirect flow.
+    /// </summary>
+    /// <param name="clientId">The verifier's client ID.</param>
+    /// <param name="nonce">The nonce from the authorization request.</param>
+    /// <param name="mdocGeneratedNonce">The mdoc-generated nonce (optional).</param>
+    /// <param name="responseUri">The response URI.</param>
+    /// <returns>A SessionTranscript configured for OpenID4VP.</returns>
+    public static SessionTranscript ForOpenId4Vp(
+        string clientId,
+        string nonce,
+        string? mdocGeneratedNonce,
+        string responseUri)
+    {
+        var handover = OpenId4VpHandover.Create(clientId, responseUri, nonce, mdocGeneratedNonce ?? string.Empty);
+        return new SessionTranscript
+        {
+            DeviceEngagement = null,
+            EReaderKeyPub = null,
+            Handover = handover
+        };
+    }
+
+    /// <summary>
+    /// Creates a SessionTranscript for OpenID4VP DC API flow.
+    /// </summary>
+    /// <param name="origin">The verifier's origin.</param>
+    /// <param name="nonce">The nonce from the request.</param>
+    /// <param name="clientId">The client ID (optional, defaults to origin).</param>
+    /// <returns>A SessionTranscript configured for DC API.</returns>
+    public static SessionTranscript ForOpenId4VpDcApi(
+        string origin,
+        string nonce,
+        string? clientId)
+    {
+        var handover = OpenId4VpDcApiHandover.Create(origin, clientId ?? origin, nonce);
+        return new SessionTranscript
+        {
+            DeviceEngagement = null,
+            EReaderKeyPub = null,
+            Handover = handover
+        };
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Issuer/MdocIssuer.cs
+++ b/src/SdJwt.Net.Mdoc/Issuer/MdocIssuer.cs
@@ -1,0 +1,158 @@
+using System.Security.Cryptography;
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Models;
+
+namespace SdJwt.Net.Mdoc.Issuer;
+
+/// <summary>
+/// Issues mdoc credentials per ISO 18013-5.
+/// </summary>
+public class MdocIssuer
+{
+    private readonly ECDsa _issuerKey;
+    private readonly CoseAlgorithm _algorithm;
+    private readonly MdocIssuerOptions _options;
+    private readonly CoseKey? _deviceKey;
+    private readonly Dictionary<string, Dictionary<string, object>> _claims;
+    private readonly byte[]? _issuerCertificate;
+    private readonly ICoseCryptoProvider _cryptoProvider;
+
+    internal MdocIssuer(
+        ECDsa issuerKey,
+        CoseAlgorithm algorithm,
+        MdocIssuerOptions options,
+        CoseKey? deviceKey,
+        Dictionary<string, Dictionary<string, object>> claims,
+        byte[]? issuerCertificate,
+        ICoseCryptoProvider cryptoProvider)
+    {
+        _issuerKey = issuerKey;
+        _algorithm = algorithm;
+        _options = options;
+        _deviceKey = deviceKey;
+        _claims = claims;
+        _issuerCertificate = issuerCertificate;
+        _cryptoProvider = cryptoProvider;
+    }
+
+    /// <summary>
+    /// Creates a new MdocIssuerBuilder.
+    /// </summary>
+    /// <returns>A new builder instance.</returns>
+    public static MdocIssuerBuilder CreateBuilder()
+    {
+        return new MdocIssuerBuilder();
+    }
+
+    /// <summary>
+    /// Issues the mdoc credential.
+    /// </summary>
+    /// <returns>The issued IssuerSigned structure.</returns>
+    public IssuerSigned Issue()
+    {
+        var issuerSigned = new IssuerSigned();
+        var valueDigestsByNamespace = new Dictionary<string, DigestIdMapping>();
+
+        // Generate IssuerSignedItems for each namespace
+        foreach (var (nameSpace, elements) in _claims)
+        {
+            var items = new List<IssuerSignedItem>();
+            var digests = new DigestIdMapping();
+            var digestId = 0;
+
+            foreach (var (elementId, value) in elements)
+            {
+                var item = new IssuerSignedItem
+                {
+                    DigestId = digestId,
+                    Random = GenerateRandom(),
+                    ElementIdentifier = elementId,
+                    ElementValue = value
+                };
+                items.Add(item);
+
+                // Compute digest of the tagged CBOR
+                var itemBytes = CBORObject.FromObjectAndTag(item.ToCbor(), 24).EncodeToBytes();
+                var digest = ComputeSha256(itemBytes);
+                digests.Digests[digestId] = digest;
+
+                digestId++;
+            }
+
+            issuerSigned.NameSpaces[nameSpace] = items;
+            valueDigestsByNamespace[nameSpace] = digests;
+        }
+
+        // Build MSO
+        var mso = new MobileSecurityObject
+        {
+            Version = "1.0",
+            DigestAlgorithm = "SHA-256",
+            DocType = _options.DocType,
+            ValueDigests = valueDigestsByNamespace,
+            ValidityInfo = new ValidityInfo
+            {
+                Signed = _options.ValidFrom,
+                ValidFrom = _options.ValidFrom,
+                ValidUntil = _options.ValidUntil,
+                ExpectedUpdate = _options.ExpectedUpdate
+            }
+        };
+
+        // Add device key if provided
+        if (_deviceKey != null)
+        {
+            mso.DeviceKeyInfo = new DeviceKeyInfo
+            {
+                DeviceKey = _deviceKey.ToCbor()
+            };
+        }
+
+        // Sign MSO as COSE_Sign1
+        var msoBytes = mso.ToCbor();
+        var coseSign1 = new CoseSign1(_algorithm, msoBytes);
+
+        // Add x5chain if certificate provided
+        if (_issuerCertificate != null)
+        {
+            coseSign1.UnprotectedHeaders["x5chain"] = _issuerCertificate;
+        }
+
+        issuerSigned.IssuerAuth = _cryptoProvider.Sign(coseSign1, _issuerKey);
+
+        return issuerSigned;
+    }
+
+    /// <summary>
+    /// Issues the mdoc credential asynchronously.
+    /// </summary>
+    /// <returns>The issued Document.</returns>
+    public Task<Document> IssueAsync()
+    {
+        var issuerSigned = Issue();
+        var document = new Document
+        {
+            DocType = _options.DocType,
+            IssuerSigned = issuerSigned
+        };
+        return Task.FromResult(document);
+    }
+
+    private static byte[] GenerateRandom()
+    {
+        var random = new byte[16];
+        RandomNumberGenerator.Fill(random);
+        return random;
+    }
+
+    private static byte[] ComputeSha256(byte[] data)
+    {
+#if NETSTANDARD2_1
+        using var sha256 = SHA256.Create();
+        return sha256.ComputeHash(data);
+#else
+        return SHA256.HashData(data);
+#endif
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Issuer/MdocIssuerBuilder.cs
+++ b/src/SdJwt.Net.Mdoc/Issuer/MdocIssuerBuilder.cs
@@ -1,0 +1,203 @@
+using System.Security.Cryptography;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Models;
+using SdJwt.Net.Mdoc.Namespaces;
+
+namespace SdJwt.Net.Mdoc.Issuer;
+
+/// <summary>
+/// Fluent builder for creating mdoc credentials.
+/// </summary>
+public class MdocIssuerBuilder
+{
+    private readonly MdocIssuerOptions _options = new();
+    private ECDsa? _issuerKey;
+    private CoseAlgorithm _algorithm = CoseAlgorithm.ES256;
+    private CoseKey? _deviceKey;
+    private readonly Dictionary<string, Dictionary<string, object>> _claims = new();
+    private byte[]? _issuerCertificate;
+    private ICoseCryptoProvider? _cryptoProvider;
+
+    /// <summary>
+    /// Sets the document type.
+    /// </summary>
+    /// <param name="docType">The document type identifier.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder WithDocType(string docType)
+    {
+        _options.DocType = docType;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the issuer signing key.
+    /// </summary>
+    /// <param name="key">The ECDsa private key.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder WithIssuerKey(ECDsa key)
+    {
+        _issuerKey = key;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the issuer signing key from a COSE key.
+    /// </summary>
+    /// <param name="key">The COSE key containing the private key.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder WithIssuerKey(CoseKey key)
+    {
+        _issuerKey = key.ToECDsa();
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the signing algorithm.
+    /// </summary>
+    /// <param name="algorithm">The COSE algorithm.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder WithAlgorithm(CoseAlgorithm algorithm)
+    {
+        _algorithm = algorithm;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the device key for holder binding.
+    /// </summary>
+    /// <param name="deviceKey">The device's public key.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder WithDeviceKey(CoseKey deviceKey)
+    {
+        _deviceKey = deviceKey;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the issuer certificate for x5chain header.
+    /// </summary>
+    /// <param name="certificate">The issuer's X.509 certificate bytes.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder WithIssuerCertificate(byte[] certificate)
+    {
+        _issuerCertificate = certificate;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the validity period.
+    /// </summary>
+    /// <param name="validFrom">Start of validity period.</param>
+    /// <param name="validUntil">End of validity period.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder WithValidity(DateTimeOffset validFrom, DateTimeOffset validUntil)
+    {
+        _options.ValidFrom = validFrom;
+        _options.ValidUntil = validUntil;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the expected update timestamp.
+    /// </summary>
+    /// <param name="expectedUpdate">Expected update timestamp.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder WithExpectedUpdate(DateTimeOffset expectedUpdate)
+    {
+        _options.ExpectedUpdate = expectedUpdate;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a claim to a namespace.
+    /// </summary>
+    /// <param name="nameSpace">The namespace.</param>
+    /// <param name="elementIdentifier">The element identifier.</param>
+    /// <param name="value">The claim value.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder AddClaim(string nameSpace, string elementIdentifier, object value)
+    {
+        if (!_claims.ContainsKey(nameSpace))
+        {
+            _claims[nameSpace] = new Dictionary<string, object>();
+        }
+        _claims[nameSpace][elementIdentifier] = value;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds multiple claims to a namespace.
+    /// </summary>
+    /// <param name="nameSpace">The namespace.</param>
+    /// <param name="claims">Dictionary of element identifiers to values.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder AddClaims(string nameSpace, Dictionary<string, object> claims)
+    {
+        foreach (var (key, value) in claims)
+        {
+            AddClaim(nameSpace, key, value);
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an mDL data element to the mDL namespace.
+    /// </summary>
+    /// <param name="element">The mDL data element.</param>
+    /// <param name="value">The claim value.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder AddMdlElement(MdlDataElement element, object value)
+    {
+        var elementName = element.ToElementIdentifier();
+        return AddClaim(MdlNamespace.Namespace, elementName, value);
+    }
+
+    /// <summary>
+    /// Sets a custom crypto provider.
+    /// </summary>
+    /// <param name="provider">The crypto provider.</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder WithCryptoProvider(ICoseCryptoProvider provider)
+    {
+        _cryptoProvider = provider;
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the MdocIssuer instance.
+    /// </summary>
+    /// <returns>A configured MdocIssuer.</returns>
+    public MdocIssuer Build()
+    {
+        if (_issuerKey == null)
+        {
+            throw new InvalidOperationException("Issuer key is required.");
+        }
+
+        if (string.IsNullOrEmpty(_options.DocType))
+        {
+            throw new InvalidOperationException("DocType is required.");
+        }
+
+        return new MdocIssuer(
+            _issuerKey,
+            _algorithm,
+            _options,
+            _deviceKey,
+            _claims,
+            _issuerCertificate,
+            _cryptoProvider ?? new DefaultCoseCryptoProvider());
+    }
+
+    /// <summary>
+    /// Builds and issues an mdoc asynchronously.
+    /// </summary>
+    /// <param name="cryptoProvider">The crypto provider to use.</param>
+    /// <returns>The issued document.</returns>
+    public Task<Document> BuildAsync(ICoseCryptoProvider cryptoProvider)
+    {
+        _cryptoProvider = cryptoProvider;
+        var issuer = Build();
+        return issuer.IssueAsync();
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Issuer/MdocIssuerOptions.cs
+++ b/src/SdJwt.Net.Mdoc/Issuer/MdocIssuerOptions.cs
@@ -1,0 +1,32 @@
+namespace SdJwt.Net.Mdoc.Issuer;
+
+/// <summary>
+/// Options for mdoc issuance.
+/// </summary>
+public class MdocIssuerOptions
+{
+    /// <summary>
+    /// Document type (e.g., "org.iso.18013.5.1.mDL").
+    /// </summary>
+    public string DocType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Validity period start (signed timestamp).
+    /// </summary>
+    public DateTimeOffset ValidFrom { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Validity period end (signed timestamp).
+    /// </summary>
+    public DateTimeOffset ValidUntil { get; set; } = DateTimeOffset.UtcNow.AddYears(1);
+
+    /// <summary>
+    /// Expected update timestamp (optional).
+    /// </summary>
+    public DateTimeOffset? ExpectedUpdate { get; set; }
+
+    /// <summary>
+    /// Include device key in MSO for holder binding.
+    /// </summary>
+    public bool IncludeDeviceKey { get; set; } = true;
+}

--- a/src/SdJwt.Net.Mdoc/Models/DeviceResponse.cs
+++ b/src/SdJwt.Net.Mdoc/Models/DeviceResponse.cs
@@ -1,0 +1,123 @@
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Models;
+
+/// <summary>
+/// DeviceResponse structure per ISO 18013-5.
+/// Contains one or more documents presented by the holder.
+/// </summary>
+public class DeviceResponse : ICborSerializable
+{
+    /// <summary>
+    /// Version of the DeviceResponse structure.
+    /// </summary>
+    public string Version { get; set; } = "1.0";
+
+    /// <summary>
+    /// Documents included in the response.
+    /// </summary>
+    public List<Document> Documents { get; set; } = new();
+
+    /// <summary>
+    /// Document errors for documents that could not be returned.
+    /// </summary>
+    public List<DocumentError>? DocumentErrors { get; set; }
+
+    /// <summary>
+    /// Overall status code.
+    /// </summary>
+    public int Status { get; set; } = 0;
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+        cbor.Add("version", Version);
+
+        var docsArray = CBORObject.NewArray();
+        foreach (var doc in Documents)
+        {
+            docsArray.Add(doc.ToCborObject());
+        }
+        cbor.Add("documents", docsArray);
+
+        if (DocumentErrors != null && DocumentErrors.Count > 0)
+        {
+            var errorsArray = CBORObject.NewArray();
+            foreach (var error in DocumentErrors)
+            {
+                var errorMap = CBORObject.NewMap();
+                errorMap.Add(error.DocType, error.ErrorCode);
+                errorsArray.Add(errorMap);
+            }
+            cbor.Add("documentErrors", errorsArray);
+        }
+
+        cbor.Add("status", Status);
+
+        return cbor;
+    }
+
+    /// <summary>
+    /// Creates a DeviceResponse from CBOR bytes.
+    /// </summary>
+    /// <param name="cbor">The CBOR bytes.</param>
+    /// <returns>A new DeviceResponse instance.</returns>
+    public static DeviceResponse FromCbor(byte[] cbor)
+    {
+        return FromCborObject(CBORObject.DecodeFromBytes(cbor));
+    }
+
+    /// <summary>
+    /// Creates a DeviceResponse from a CBOR object.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new DeviceResponse instance.</returns>
+    public static DeviceResponse FromCborObject(CBORObject cbor)
+    {
+        var response = new DeviceResponse();
+
+        if (cbor.ContainsKey("version"))
+        {
+            response.Version = cbor["version"].AsString();
+        }
+
+        if (cbor.ContainsKey("documents"))
+        {
+            foreach (var docCbor in cbor["documents"].Values)
+            {
+                response.Documents.Add(Document.FromCborObject(docCbor));
+            }
+        }
+
+        if (cbor.ContainsKey("documentErrors"))
+        {
+            response.DocumentErrors = new List<DocumentError>();
+            foreach (var errorCbor in cbor["documentErrors"].Values)
+            {
+                foreach (var key in errorCbor.Keys)
+                {
+                    response.DocumentErrors.Add(new DocumentError
+                    {
+                        DocType = key.AsString(),
+                        ErrorCode = errorCbor[key].AsInt32()
+                    });
+                }
+            }
+        }
+
+        if (cbor.ContainsKey("status"))
+        {
+            response.Status = cbor["status"].AsInt32();
+        }
+
+        return response;
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Models/DigestIdMapping.cs
+++ b/src/SdJwt.Net.Mdoc/Models/DigestIdMapping.cs
@@ -1,0 +1,118 @@
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Models;
+
+/// <summary>
+/// Digest ID to element mapping.
+/// </summary>
+public class DigestIdMapping : ICborSerializable
+{
+    /// <summary>
+    /// Mapping of digest ID to digest value.
+    /// </summary>
+    public Dictionary<int, byte[]> Digests { get; set; } = new();
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+        foreach (var (digestId, digest) in Digests)
+        {
+            cbor.Add(digestId, digest);
+        }
+        return cbor;
+    }
+
+    /// <summary>
+    /// Creates a DigestIdMapping from CBOR.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new DigestIdMapping instance.</returns>
+    public static DigestIdMapping FromCborObject(CBORObject cbor)
+    {
+        var mapping = new DigestIdMapping();
+        foreach (var key in cbor.Keys)
+        {
+            mapping.Digests[key.AsInt32()] = cbor[key].GetByteString();
+        }
+        return mapping;
+    }
+}
+
+/// <summary>
+/// Device key information for holder binding.
+/// </summary>
+public class DeviceKeyInfo : ICborSerializable
+{
+    /// <summary>
+    /// The device public key in COSE_Key format.
+    /// </summary>
+    public byte[] DeviceKey { get; set; } = Array.Empty<byte>();
+
+    /// <summary>
+    /// Optional key authorizations.
+    /// </summary>
+    public Dictionary<string, object>? KeyAuthorizations { get; set; }
+
+    /// <summary>
+    /// Optional key info.
+    /// </summary>
+    public Dictionary<string, object>? KeyInfo { get; set; }
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+        cbor.Add("deviceKey", CBORObject.DecodeFromBytes(DeviceKey));
+
+        if (KeyAuthorizations != null)
+        {
+            var authCbor = CBORObject.NewMap();
+            foreach (var (key, value) in KeyAuthorizations)
+            {
+                authCbor.Add(key, CBORObject.FromObject(value));
+            }
+            cbor.Add("keyAuthorizations", authCbor);
+        }
+
+        return cbor;
+    }
+
+    /// <summary>
+    /// Creates a DeviceKeyInfo from CBOR.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new DeviceKeyInfo instance.</returns>
+    public static DeviceKeyInfo FromCborObject(CBORObject cbor)
+    {
+        var info = new DeviceKeyInfo
+        {
+            DeviceKey = cbor["deviceKey"].EncodeToBytes()
+        };
+
+        if (cbor.ContainsKey("keyAuthorizations"))
+        {
+            info.KeyAuthorizations = new Dictionary<string, object>();
+            var auth = cbor["keyAuthorizations"];
+            foreach (var key in auth.Keys)
+            {
+                info.KeyAuthorizations[key.AsString()] = auth[key];
+            }
+        }
+
+        return info;
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Models/Document.cs
+++ b/src/SdJwt.Net.Mdoc/Models/Document.cs
@@ -1,0 +1,249 @@
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Models;
+
+/// <summary>
+/// DeviceSigned structure with device authentication.
+/// </summary>
+public class DeviceSigned : ICborSerializable
+{
+    /// <summary>
+    /// Namespaced data elements signed by the device.
+    /// </summary>
+    public Dictionary<string, List<IssuerSignedItem>> NameSpaces { get; set; } = new();
+
+    /// <summary>
+    /// Device authentication (deviceSignature or deviceMac).
+    /// </summary>
+    public DeviceAuth? DeviceAuth { get; set; }
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+
+        var nameSpacesCbor = CBORObject.NewMap();
+        foreach (var (nameSpace, items) in NameSpaces)
+        {
+            var itemsArray = CBORObject.NewArray();
+            foreach (var item in items)
+            {
+                itemsArray.Add(CBORObject.FromObjectAndTag(item.ToCbor(), 24));
+            }
+            nameSpacesCbor.Add(nameSpace, itemsArray);
+        }
+        cbor.Add("nameSpaces", CBORObject.FromObjectAndTag(nameSpacesCbor.EncodeToBytes(), 24));
+
+        if (DeviceAuth != null)
+        {
+            cbor.Add("deviceAuth", DeviceAuth.ToCborObject());
+        }
+
+        return cbor;
+    }
+
+    /// <summary>
+    /// Creates a DeviceSigned from a CBOR object.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new DeviceSigned instance.</returns>
+    public static DeviceSigned FromCborObject(CBORObject cbor)
+    {
+        var deviceSigned = new DeviceSigned();
+
+        if (cbor.ContainsKey("nameSpaces"))
+        {
+            var nameSpacesCbor = cbor["nameSpaces"];
+            if (nameSpacesCbor.HasMostOuterTag(24))
+            {
+                nameSpacesCbor = CBORObject.DecodeFromBytes(nameSpacesCbor.GetByteString());
+            }
+
+            foreach (var key in nameSpacesCbor.Keys)
+            {
+                var items = new List<IssuerSignedItem>();
+                foreach (var itemCbor in nameSpacesCbor[key].Values)
+                {
+                    var actualCbor = itemCbor.HasMostOuterTag(24)
+                        ? CBORObject.DecodeFromBytes(itemCbor.GetByteString())
+                        : itemCbor;
+                    items.Add(IssuerSignedItem.FromCborObject(actualCbor));
+                }
+                deviceSigned.NameSpaces[key.AsString()] = items;
+            }
+        }
+
+        if (cbor.ContainsKey("deviceAuth"))
+        {
+            deviceSigned.DeviceAuth = DeviceAuth.FromCborObject(cbor["deviceAuth"]);
+        }
+
+        return deviceSigned;
+    }
+}
+
+/// <summary>
+/// Device authentication (deviceSignature or deviceMac).
+/// </summary>
+public class DeviceAuth : ICborSerializable
+{
+    /// <summary>
+    /// Device signature (COSE_Sign1).
+    /// </summary>
+    public byte[]? DeviceSignature { get; set; }
+
+    /// <summary>
+    /// Device MAC (COSE_Mac0).
+    /// </summary>
+    public byte[]? DeviceMac { get; set; }
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+
+        if (DeviceSignature != null)
+        {
+            cbor.Add("deviceSignature", CBORObject.DecodeFromBytes(DeviceSignature));
+        }
+        else if (DeviceMac != null)
+        {
+            cbor.Add("deviceMac", CBORObject.DecodeFromBytes(DeviceMac));
+        }
+
+        return cbor;
+    }
+
+    /// <summary>
+    /// Creates a DeviceAuth from a CBOR object.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new DeviceAuth instance.</returns>
+    public static DeviceAuth FromCborObject(CBORObject cbor)
+    {
+        var auth = new DeviceAuth();
+
+        if (cbor.ContainsKey("deviceSignature"))
+        {
+            auth.DeviceSignature = cbor["deviceSignature"].EncodeToBytes();
+        }
+        else if (cbor.ContainsKey("deviceMac"))
+        {
+            auth.DeviceMac = cbor["deviceMac"].EncodeToBytes();
+        }
+
+        return auth;
+    }
+}
+
+/// <summary>
+/// Document error information.
+/// </summary>
+public class DocumentError
+{
+    /// <summary>
+    /// Document type that caused the error.
+    /// </summary>
+    public string DocType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Error code.
+    /// </summary>
+    public int ErrorCode { get; set; }
+}
+
+/// <summary>
+/// Individual document within a DeviceResponse.
+/// </summary>
+public class Document : ICborSerializable
+{
+    /// <summary>
+    /// Document type (e.g., "org.iso.18013.5.1.mDL").
+    /// </summary>
+    public string DocType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Issuer-signed data including namespaces and MSO.
+    /// </summary>
+    public IssuerSigned IssuerSigned { get; set; } = new();
+
+    /// <summary>
+    /// Device-signed data proving possession.
+    /// </summary>
+    public DeviceSigned? DeviceSigned { get; set; }
+
+    /// <summary>
+    /// Errors for specific data elements that could not be returned.
+    /// </summary>
+    public Dictionary<string, Dictionary<string, int>>? Errors { get; set; }
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+        cbor.Add("docType", DocType);
+        cbor.Add("issuerSigned", IssuerSigned.ToCborObject());
+
+        if (DeviceSigned != null)
+        {
+            cbor.Add("deviceSigned", DeviceSigned.ToCborObject());
+        }
+
+        if (Errors != null && Errors.Count > 0)
+        {
+            var errorsCbor = CBORObject.NewMap();
+            foreach (var (ns, nsErrors) in Errors)
+            {
+                var nsErrorsCbor = CBORObject.NewMap();
+                foreach (var (elem, code) in nsErrors)
+                {
+                    nsErrorsCbor.Add(elem, code);
+                }
+                errorsCbor.Add(ns, nsErrorsCbor);
+            }
+            cbor.Add("errors", errorsCbor);
+        }
+
+        return cbor;
+    }
+
+    /// <summary>
+    /// Creates a Document from a CBOR object.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new Document instance.</returns>
+    public static Document FromCborObject(CBORObject cbor)
+    {
+        var doc = new Document
+        {
+            DocType = cbor["docType"].AsString(),
+            IssuerSigned = IssuerSigned.FromCborObject(cbor["issuerSigned"])
+        };
+
+        if (cbor.ContainsKey("deviceSigned"))
+        {
+            doc.DeviceSigned = DeviceSigned.FromCborObject(cbor["deviceSigned"]);
+        }
+
+        return doc;
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Models/IssuerSigned.cs
+++ b/src/SdJwt.Net.Mdoc/Models/IssuerSigned.cs
@@ -1,0 +1,184 @@
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Models;
+
+/// <summary>
+/// Individual data element in IssuerSigned.
+/// </summary>
+public class IssuerSignedItem : ICborSerializable
+{
+    /// <summary>
+    /// The digest ID for this item.
+    /// </summary>
+    public int DigestId { get; set; }
+
+    /// <summary>
+    /// Random bytes for digest computation (salt).
+    /// </summary>
+    public byte[] Random { get; set; } = Array.Empty<byte>();
+
+    /// <summary>
+    /// The element identifier (claim name).
+    /// </summary>
+    public string ElementIdentifier { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The element value.
+    /// </summary>
+    public object? ElementValue { get; set; }
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+        cbor.Add("digestID", DigestId);
+        cbor.Add("random", Random);
+        cbor.Add("elementIdentifier", ElementIdentifier);
+        cbor.Add("elementValue", CBORObject.FromObject(ElementValue));
+        return cbor;
+    }
+
+    /// <summary>
+    /// Creates an IssuerSignedItem from a CBOR object.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new IssuerSignedItem instance.</returns>
+    public static IssuerSignedItem FromCborObject(CBORObject cbor)
+    {
+        var item = new IssuerSignedItem
+        {
+            DigestId = cbor["digestID"].AsInt32(),
+            Random = cbor["random"].GetByteString(),
+            ElementIdentifier = cbor["elementIdentifier"].AsString()
+        };
+
+        var elementValue = cbor["elementValue"];
+        item.ElementValue = ConvertCborValue(elementValue);
+
+        return item;
+    }
+
+    private static object? ConvertCborValue(CBORObject cbor)
+    {
+        if (cbor.IsNull) return null;
+
+        return cbor.Type switch
+        {
+            CBORType.Boolean => cbor.AsBoolean(),
+            CBORType.Integer => cbor.AsInt32(),
+            CBORType.FloatingPoint => cbor.AsDouble(),
+            CBORType.TextString => cbor.AsString(),
+            CBORType.ByteString => cbor.GetByteString(),
+            _ => cbor
+        };
+    }
+}
+
+/// <summary>
+/// IssuerSigned structure containing namespaced data elements and issuer authentication.
+/// </summary>
+public class IssuerSigned : ICborSerializable
+{
+    /// <summary>
+    /// Namespaced data elements.
+    /// Key: namespace, Value: list of IssuerSignedItems.
+    /// </summary>
+    public Dictionary<string, List<IssuerSignedItem>> NameSpaces { get; set; } = new();
+
+    /// <summary>
+    /// Issuer authentication (COSE_Sign1 containing MSO).
+    /// </summary>
+    public byte[] IssuerAuth { get; set; } = Array.Empty<byte>();
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+
+        var nameSpacesCbor = CBORObject.NewMap();
+        foreach (var (nameSpace, items) in NameSpaces)
+        {
+            var itemsArray = CBORObject.NewArray();
+            foreach (var item in items)
+            {
+                // Each item is tagged with 24 (encoded CBOR data item)
+                var itemCbor = CBORObject.FromObjectAndTag(item.ToCbor(), 24);
+                itemsArray.Add(itemCbor);
+            }
+            nameSpacesCbor.Add(nameSpace, itemsArray);
+        }
+        cbor.Add("nameSpaces", nameSpacesCbor);
+
+        if (IssuerAuth.Length > 0)
+        {
+            cbor.Add("issuerAuth", CBORObject.DecodeFromBytes(IssuerAuth));
+        }
+
+        return cbor;
+    }
+
+    /// <summary>
+    /// Creates an IssuerSigned from CBOR bytes.
+    /// </summary>
+    /// <param name="cborData">The CBOR-encoded data.</param>
+    /// <returns>A new IssuerSigned instance.</returns>
+    public static IssuerSigned FromCbor(byte[] cborData)
+    {
+        if (cborData == null) throw new ArgumentNullException(nameof(cborData));
+        var cbor = CBORObject.DecodeFromBytes(cborData);
+        return FromCborObject(cbor);
+    }
+
+    /// <summary>
+    /// Creates an IssuerSigned from a CBOR object.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new IssuerSigned instance.</returns>
+    public static IssuerSigned FromCborObject(CBORObject cbor)
+    {
+        var issuerSigned = new IssuerSigned();
+
+        if (cbor.ContainsKey("nameSpaces"))
+        {
+            var nameSpacesCbor = cbor["nameSpaces"];
+            foreach (var key in nameSpacesCbor.Keys)
+            {
+                var nameSpace = key.AsString();
+                var items = new List<IssuerSignedItem>();
+
+                var itemsArray = nameSpacesCbor[key];
+                foreach (var itemCbor in itemsArray.Values)
+                {
+                    // Unwrap tag 24 if present
+                    var actualCbor = itemCbor.HasMostOuterTag(24)
+                        ? CBORObject.DecodeFromBytes(itemCbor.GetByteString())
+                        : itemCbor;
+
+                    items.Add(IssuerSignedItem.FromCborObject(actualCbor));
+                }
+
+                issuerSigned.NameSpaces[nameSpace] = items;
+            }
+        }
+
+        if (cbor.ContainsKey("issuerAuth"))
+        {
+            issuerSigned.IssuerAuth = cbor["issuerAuth"].EncodeToBytes();
+        }
+
+        return issuerSigned;
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Models/MobileSecurityObject.cs
+++ b/src/SdJwt.Net.Mdoc/Models/MobileSecurityObject.cs
@@ -1,0 +1,118 @@
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Models;
+
+/// <summary>
+/// Mobile Security Object as defined in ISO 18013-5 Section 9.1.2.4.
+/// Contains the issuer-signed metadata and digest values for verifying IssuerSigned items.
+/// </summary>
+public class MobileSecurityObject : ICborSerializable
+{
+    /// <summary>
+    /// Version of the MSO structure. Must be "1.0" per ISO 18013-5.
+    /// </summary>
+    public string Version { get; set; } = "1.0";
+
+    /// <summary>
+    /// Digest algorithm used. Must be "SHA-256" or "SHA-384" or "SHA-512".
+    /// </summary>
+    public string DigestAlgorithm { get; set; } = "SHA-256";
+
+    /// <summary>
+    /// Mapping of digest values per namespace.
+    /// Key: nameSpace, Value: DigestIdMapping
+    /// </summary>
+    public Dictionary<string, DigestIdMapping> ValueDigests { get; set; } = new();
+
+    /// <summary>
+    /// Device key information for holder binding.
+    /// </summary>
+    public DeviceKeyInfo DeviceKeyInfo { get; set; } = new();
+
+    /// <summary>
+    /// Document type (e.g., "org.iso.18013.5.1.mDL").
+    /// </summary>
+    public string DocType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Validity information for the credential.
+    /// </summary>
+    public ValidityInfo ValidityInfo { get; set; } = new();
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+        cbor.Add("version", Version);
+        cbor.Add("digestAlgorithm", DigestAlgorithm);
+        cbor.Add("docType", DocType);
+
+        var valueDigestsCbor = CBORObject.NewMap();
+        foreach (var (nameSpace, digests) in ValueDigests)
+        {
+            valueDigestsCbor.Add(nameSpace, digests.ToCborObject());
+        }
+        cbor.Add("valueDigests", valueDigestsCbor);
+
+        // Only include deviceKeyInfo if we have a device key
+        if (DeviceKeyInfo.DeviceKey.Length > 0)
+        {
+            cbor.Add("deviceKeyInfo", DeviceKeyInfo.ToCborObject());
+        }
+        cbor.Add("validityInfo", ValidityInfo.ToCborObject());
+
+        return cbor;
+    }
+
+    /// <summary>
+    /// Creates a MobileSecurityObject from CBOR bytes.
+    /// </summary>
+    /// <param name="cborData">The CBOR-encoded data.</param>
+    /// <returns>A new MobileSecurityObject instance.</returns>
+    public static MobileSecurityObject FromCbor(byte[] cborData)
+    {
+        if (cborData == null) throw new ArgumentNullException(nameof(cborData));
+        var cbor = CBORObject.DecodeFromBytes(cborData);
+        return FromCborObject(cbor);
+    }
+
+    /// <summary>
+    /// Creates a MobileSecurityObject from a CBOR object.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new MobileSecurityObject instance.</returns>
+    public static MobileSecurityObject FromCborObject(CBORObject cbor)
+    {
+        var mso = new MobileSecurityObject
+        {
+            Version = cbor["version"].AsString(),
+            DigestAlgorithm = cbor["digestAlgorithm"].AsString(),
+            DocType = cbor["docType"].AsString()
+        };
+
+        var valueDigestsCbor = cbor["valueDigests"];
+        foreach (var key in valueDigestsCbor.Keys)
+        {
+            mso.ValueDigests[key.AsString()] = DigestIdMapping.FromCborObject(valueDigestsCbor[key]);
+        }
+
+        if (cbor.ContainsKey("deviceKeyInfo"))
+        {
+            mso.DeviceKeyInfo = DeviceKeyInfo.FromCborObject(cbor["deviceKeyInfo"]);
+        }
+
+        if (cbor.ContainsKey("validityInfo"))
+        {
+            mso.ValidityInfo = ValidityInfo.FromCborObject(cbor["validityInfo"]);
+        }
+
+        return mso;
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Models/ValidityInfo.cs
+++ b/src/SdJwt.Net.Mdoc/Models/ValidityInfo.cs
@@ -1,0 +1,74 @@
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cbor;
+
+namespace SdJwt.Net.Mdoc.Models;
+
+/// <summary>
+/// Validity information per ISO 18013-5 Section 9.1.2.4.
+/// </summary>
+public class ValidityInfo : ICborSerializable
+{
+    /// <summary>
+    /// Timestamp when the MSO was signed.
+    /// </summary>
+    public DateTimeOffset Signed { get; set; }
+
+    /// <summary>
+    /// Timestamp from which the MSO is valid.
+    /// </summary>
+    public DateTimeOffset ValidFrom { get; set; }
+
+    /// <summary>
+    /// Timestamp until which the MSO is valid.
+    /// </summary>
+    public DateTimeOffset ValidUntil { get; set; }
+
+    /// <summary>
+    /// Optional expected update timestamp.
+    /// </summary>
+    public DateTimeOffset? ExpectedUpdate { get; set; }
+
+    /// <inheritdoc/>
+    public byte[] ToCbor()
+    {
+        return ToCborObject().EncodeToBytes();
+    }
+
+    /// <inheritdoc/>
+    public CBORObject ToCborObject()
+    {
+        var cbor = CBORObject.NewMap();
+        cbor.Add("signed", CBORObject.FromObjectAndTag(Signed.ToString("yyyy-MM-ddTHH:mm:ssZ"), 0));
+        cbor.Add("validFrom", CBORObject.FromObjectAndTag(ValidFrom.ToString("yyyy-MM-ddTHH:mm:ssZ"), 0));
+        cbor.Add("validUntil", CBORObject.FromObjectAndTag(ValidUntil.ToString("yyyy-MM-ddTHH:mm:ssZ"), 0));
+
+        if (ExpectedUpdate.HasValue)
+        {
+            cbor.Add("expectedUpdate", CBORObject.FromObjectAndTag(ExpectedUpdate.Value.ToString("yyyy-MM-ddTHH:mm:ssZ"), 0));
+        }
+
+        return cbor;
+    }
+
+    /// <summary>
+    /// Creates a ValidityInfo from CBOR.
+    /// </summary>
+    /// <param name="cbor">The CBOR object.</param>
+    /// <returns>A new ValidityInfo instance.</returns>
+    public static ValidityInfo FromCborObject(CBORObject cbor)
+    {
+        var info = new ValidityInfo
+        {
+            Signed = DateTimeOffset.Parse(cbor["signed"].AsString()),
+            ValidFrom = DateTimeOffset.Parse(cbor["validFrom"].AsString()),
+            ValidUntil = DateTimeOffset.Parse(cbor["validUntil"].AsString())
+        };
+
+        if (cbor.ContainsKey("expectedUpdate"))
+        {
+            info.ExpectedUpdate = DateTimeOffset.Parse(cbor["expectedUpdate"].AsString());
+        }
+
+        return info;
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Namespaces/MdlDataElement.cs
+++ b/src/SdJwt.Net.Mdoc/Namespaces/MdlDataElement.cs
@@ -1,0 +1,270 @@
+namespace SdJwt.Net.Mdoc.Namespaces;
+
+/// <summary>
+/// Data elements defined in the mDL namespace per ISO 18013-5.
+/// </summary>
+public enum MdlDataElement
+{
+    /// <summary>
+    /// Family name of the holder.
+    /// </summary>
+    FamilyName,
+
+    /// <summary>
+    /// Given name of the holder.
+    /// </summary>
+    GivenName,
+
+    /// <summary>
+    /// Date of birth.
+    /// </summary>
+    BirthDate,
+
+    /// <summary>
+    /// Date of issue.
+    /// </summary>
+    IssueDate,
+
+    /// <summary>
+    /// Date of expiry.
+    /// </summary>
+    ExpiryDate,
+
+    /// <summary>
+    /// Issuing country (alpha-2 or alpha-3 code).
+    /// </summary>
+    IssuingCountry,
+
+    /// <summary>
+    /// Issuing authority.
+    /// </summary>
+    IssuingAuthority,
+
+    /// <summary>
+    /// Document number.
+    /// </summary>
+    DocumentNumber,
+
+    /// <summary>
+    /// Portrait image of the holder.
+    /// </summary>
+    Portrait,
+
+    /// <summary>
+    /// Driving privileges.
+    /// </summary>
+    DrivingPrivileges,
+
+    /// <summary>
+    /// UN distinguishing sign.
+    /// </summary>
+    UnDistinguishingSign,
+
+    /// <summary>
+    /// Administrative number.
+    /// </summary>
+    AdministrativeNumber,
+
+    /// <summary>
+    /// Sex of the holder.
+    /// </summary>
+    Sex,
+
+    /// <summary>
+    /// Height of the holder.
+    /// </summary>
+    Height,
+
+    /// <summary>
+    /// Weight of the holder.
+    /// </summary>
+    Weight,
+
+    /// <summary>
+    /// Eye color.
+    /// </summary>
+    EyeColour,
+
+    /// <summary>
+    /// Hair color.
+    /// </summary>
+    HairColour,
+
+    /// <summary>
+    /// Birth place.
+    /// </summary>
+    BirthPlace,
+
+    /// <summary>
+    /// Resident address.
+    /// </summary>
+    ResidentAddress,
+
+    /// <summary>
+    /// Portrait capture date.
+    /// </summary>
+    PortraitCaptureDate,
+
+    /// <summary>
+    /// Age in years.
+    /// </summary>
+    AgeInYears,
+
+    /// <summary>
+    /// Age birth year.
+    /// </summary>
+    AgeBirthYear,
+
+    /// <summary>
+    /// Age over 18 indicator.
+    /// </summary>
+    AgeOver18,
+
+    /// <summary>
+    /// Age over 21 indicator.
+    /// </summary>
+    AgeOver21,
+
+    /// <summary>
+    /// Issuing jurisdiction.
+    /// </summary>
+    IssuingJurisdiction,
+
+    /// <summary>
+    /// Nationality.
+    /// </summary>
+    Nationality,
+
+    /// <summary>
+    /// Resident city.
+    /// </summary>
+    ResidentCity,
+
+    /// <summary>
+    /// Resident state.
+    /// </summary>
+    ResidentState,
+
+    /// <summary>
+    /// Resident postal code.
+    /// </summary>
+    ResidentPostalCode,
+
+    /// <summary>
+    /// Resident country.
+    /// </summary>
+    ResidentCountry,
+
+    /// <summary>
+    /// Family name in national characters.
+    /// </summary>
+    FamilyNameNationalCharacter,
+
+    /// <summary>
+    /// Given name in national characters.
+    /// </summary>
+    GivenNameNationalCharacter,
+
+    /// <summary>
+    /// Signature or usual mark image.
+    /// </summary>
+    SignatureUsualMark
+}
+
+/// <summary>
+/// Extension methods for MdlDataElement enum.
+/// </summary>
+public static class MdlDataElementExtensions
+{
+    /// <summary>
+    /// Gets the element identifier string for the data element.
+    /// </summary>
+    /// <param name="element">The data element.</param>
+    /// <returns>The element identifier string.</returns>
+    public static string ToElementIdentifier(this MdlDataElement element)
+    {
+        return element switch
+        {
+            MdlDataElement.FamilyName => "family_name",
+            MdlDataElement.GivenName => "given_name",
+            MdlDataElement.BirthDate => "birth_date",
+            MdlDataElement.IssueDate => "issue_date",
+            MdlDataElement.ExpiryDate => "expiry_date",
+            MdlDataElement.IssuingCountry => "issuing_country",
+            MdlDataElement.IssuingAuthority => "issuing_authority",
+            MdlDataElement.DocumentNumber => "document_number",
+            MdlDataElement.Portrait => "portrait",
+            MdlDataElement.DrivingPrivileges => "driving_privileges",
+            MdlDataElement.UnDistinguishingSign => "un_distinguishing_sign",
+            MdlDataElement.AdministrativeNumber => "administrative_number",
+            MdlDataElement.Sex => "sex",
+            MdlDataElement.Height => "height",
+            MdlDataElement.Weight => "weight",
+            MdlDataElement.EyeColour => "eye_colour",
+            MdlDataElement.HairColour => "hair_colour",
+            MdlDataElement.BirthPlace => "birth_place",
+            MdlDataElement.ResidentAddress => "resident_address",
+            MdlDataElement.PortraitCaptureDate => "portrait_capture_date",
+            MdlDataElement.AgeInYears => "age_in_years",
+            MdlDataElement.AgeBirthYear => "age_birth_year",
+            MdlDataElement.AgeOver18 => "age_over_18",
+            MdlDataElement.AgeOver21 => "age_over_21",
+            MdlDataElement.IssuingJurisdiction => "issuing_jurisdiction",
+            MdlDataElement.Nationality => "nationality",
+            MdlDataElement.ResidentCity => "resident_city",
+            MdlDataElement.ResidentState => "resident_state",
+            MdlDataElement.ResidentPostalCode => "resident_postal_code",
+            MdlDataElement.ResidentCountry => "resident_country",
+            MdlDataElement.FamilyNameNationalCharacter => "family_name_national_character",
+            MdlDataElement.GivenNameNationalCharacter => "given_name_national_character",
+            MdlDataElement.SignatureUsualMark => "signature_usual_mark",
+            _ => throw new ArgumentOutOfRangeException(nameof(element))
+        };
+    }
+
+    /// <summary>
+    /// Parses an element identifier string to a MdlDataElement.
+    /// </summary>
+    /// <param name="elementIdentifier">The element identifier string.</param>
+    /// <returns>The corresponding MdlDataElement.</returns>
+    public static MdlDataElement? FromElementIdentifier(string elementIdentifier)
+    {
+        return elementIdentifier switch
+        {
+            "family_name" => MdlDataElement.FamilyName,
+            "given_name" => MdlDataElement.GivenName,
+            "birth_date" => MdlDataElement.BirthDate,
+            "issue_date" => MdlDataElement.IssueDate,
+            "expiry_date" => MdlDataElement.ExpiryDate,
+            "issuing_country" => MdlDataElement.IssuingCountry,
+            "issuing_authority" => MdlDataElement.IssuingAuthority,
+            "document_number" => MdlDataElement.DocumentNumber,
+            "portrait" => MdlDataElement.Portrait,
+            "driving_privileges" => MdlDataElement.DrivingPrivileges,
+            "un_distinguishing_sign" => MdlDataElement.UnDistinguishingSign,
+            "administrative_number" => MdlDataElement.AdministrativeNumber,
+            "sex" => MdlDataElement.Sex,
+            "height" => MdlDataElement.Height,
+            "weight" => MdlDataElement.Weight,
+            "eye_colour" => MdlDataElement.EyeColour,
+            "hair_colour" => MdlDataElement.HairColour,
+            "birth_place" => MdlDataElement.BirthPlace,
+            "resident_address" => MdlDataElement.ResidentAddress,
+            "portrait_capture_date" => MdlDataElement.PortraitCaptureDate,
+            "age_in_years" => MdlDataElement.AgeInYears,
+            "age_birth_year" => MdlDataElement.AgeBirthYear,
+            "age_over_18" => MdlDataElement.AgeOver18,
+            "age_over_21" => MdlDataElement.AgeOver21,
+            "issuing_jurisdiction" => MdlDataElement.IssuingJurisdiction,
+            "nationality" => MdlDataElement.Nationality,
+            "resident_city" => MdlDataElement.ResidentCity,
+            "resident_state" => MdlDataElement.ResidentState,
+            "resident_postal_code" => MdlDataElement.ResidentPostalCode,
+            "resident_country" => MdlDataElement.ResidentCountry,
+            "family_name_national_character" => MdlDataElement.FamilyNameNationalCharacter,
+            "given_name_national_character" => MdlDataElement.GivenNameNationalCharacter,
+            "signature_usual_mark" => MdlDataElement.SignatureUsualMark,
+            _ => null
+        };
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Namespaces/MdlNamespace.cs
+++ b/src/SdJwt.Net.Mdoc/Namespaces/MdlNamespace.cs
@@ -1,0 +1,76 @@
+namespace SdJwt.Net.Mdoc.Namespaces;
+
+/// <summary>
+/// Constants and helpers for the mDL namespace per ISO 18013-5.
+/// </summary>
+public static class MdlNamespace
+{
+    /// <summary>
+    /// The ISO 18013-5 mDL namespace identifier.
+    /// </summary>
+    public const string Namespace = "org.iso.18013.5.1";
+
+    /// <summary>
+    /// The mDL document type identifier.
+    /// </summary>
+    public const string DocType = "org.iso.18013.5.1.mDL";
+
+    /// <summary>
+    /// Mandatory elements for mDL per ISO 18013-5.
+    /// </summary>
+    public static readonly IReadOnlyList<MdlDataElement> MandatoryElements = new[]
+    {
+        MdlDataElement.FamilyName,
+        MdlDataElement.GivenName,
+        MdlDataElement.BirthDate,
+        MdlDataElement.IssueDate,
+        MdlDataElement.ExpiryDate,
+        MdlDataElement.IssuingCountry,
+        MdlDataElement.IssuingAuthority,
+        MdlDataElement.DocumentNumber,
+        MdlDataElement.Portrait,
+        MdlDataElement.DrivingPrivileges,
+        MdlDataElement.UnDistinguishingSign
+    };
+
+    /// <summary>
+    /// Gets the full element identifier with namespace prefix.
+    /// </summary>
+    /// <param name="element">The data element.</param>
+    /// <returns>The full element identifier.</returns>
+    public static string GetFullIdentifier(MdlDataElement element)
+    {
+        return $"{Namespace}.{element.ToElementIdentifier()}";
+    }
+
+    /// <summary>
+    /// Checks if an element is mandatory for mDL.
+    /// </summary>
+    /// <param name="element">The data element.</param>
+    /// <returns>True if the element is mandatory.</returns>
+    public static bool IsMandatory(MdlDataElement element)
+    {
+        return MandatoryElements.Contains(element);
+    }
+
+    /// <summary>
+    /// Creates a claims dictionary for the mDL namespace.
+    /// </summary>
+    /// <param name="claims">The claims to add.</param>
+    /// <returns>A dictionary with the mDL namespace as key.</returns>
+    public static Dictionary<string, Dictionary<string, object>> CreateClaims(
+        Dictionary<MdlDataElement, object> claims)
+    {
+        var result = new Dictionary<string, Dictionary<string, object>>
+        {
+            [Namespace] = new Dictionary<string, object>()
+        };
+
+        foreach (var (element, value) in claims)
+        {
+            result[Namespace][element.ToElementIdentifier()] = value;
+        }
+
+        return result;
+    }
+}

--- a/src/SdJwt.Net.Mdoc/SdJwt.Net.Mdoc.csproj
+++ b/src/SdJwt.Net.Mdoc/SdJwt.Net.Mdoc.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.1</TargetFrameworks>
+        <Description>ISO 18013-5 mDL/mdoc implementation for the SD-JWT .NET ecosystem. Provides
+            credential issuance, presentation, and verification for mobile document credentials with
+            OpenID4VP/OpenID4VCI integration and HAIP compliance.</Description>
+        <PackageTags>
+            sd-jwt;mdoc;mdl;iso-18013-5;mobile-driving-license;credential;cose;cbor;openid4vp;openid4vci;haip;eudiw</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- CBOR Serialization -->
+        <PackageReference Include="PeterO.Cbor" Version="4.5.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Existing ecosystem integration -->
+        <ProjectReference Include="..\SdJwt.Net\SdJwt.Net.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/SdJwt.Net.Mdoc/Verifier/MdocVerificationOptions.cs
+++ b/src/SdJwt.Net.Mdoc/Verifier/MdocVerificationOptions.cs
@@ -1,0 +1,42 @@
+namespace SdJwt.Net.Mdoc.Verifier;
+
+/// <summary>
+/// Options for mdoc verification.
+/// </summary>
+public class MdocVerificationOptions
+{
+    /// <summary>
+    /// Allowed document types. If empty, all types are allowed.
+    /// </summary>
+    public List<string> AllowedDocTypes { get; set; } = new();
+
+    /// <summary>
+    /// Whether to verify the issuer certificate chain.
+    /// </summary>
+    public bool VerifyCertificateChain { get; set; } = true;
+
+    /// <summary>
+    /// Whether to verify validity timestamps.
+    /// </summary>
+    public bool VerifyValidity { get; set; } = true;
+
+    /// <summary>
+    /// Whether to verify device signature.
+    /// </summary>
+    public bool VerifyDeviceSignature { get; set; } = true;
+
+    /// <summary>
+    /// Clock skew tolerance for validity checks.
+    /// </summary>
+    public TimeSpan ClockSkewTolerance { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Current time for validity checks. If null, uses DateTimeOffset.UtcNow.
+    /// </summary>
+    public DateTimeOffset? CurrentTime { get; set; }
+
+    /// <summary>
+    /// Trusted issuer certificates for chain validation.
+    /// </summary>
+    public List<byte[]> TrustedIssuers { get; set; } = new();
+}

--- a/src/SdJwt.Net.Mdoc/Verifier/MdocVerificationResult.cs
+++ b/src/SdJwt.Net.Mdoc/Verifier/MdocVerificationResult.cs
@@ -1,0 +1,83 @@
+using SdJwt.Net.Mdoc.Models;
+
+namespace SdJwt.Net.Mdoc.Verifier;
+
+/// <summary>
+/// Result of mdoc verification.
+/// </summary>
+public class MdocVerificationResult
+{
+    /// <summary>
+    /// Whether the verification was successful overall.
+    /// </summary>
+    public bool IsValid { get; set; }
+
+    /// <summary>
+    /// Whether the issuer signature was valid.
+    /// </summary>
+    public bool IssuerSignatureValid { get; set; }
+
+    /// <summary>
+    /// Whether the device signature was valid (if present).
+    /// </summary>
+    public bool DeviceSignatureValid { get; set; } = true;
+
+    /// <summary>
+    /// Whether all value digests matched.
+    /// </summary>
+    public bool DigestsValid { get; set; }
+
+    /// <summary>
+    /// Whether the credential is within its validity period.
+    /// </summary>
+    public bool ValidityPeriodValid { get; set; }
+
+    /// <summary>
+    /// Whether the certificate chain was valid.
+    /// </summary>
+    public bool CertificateChainValid { get; set; } = true;
+
+    /// <summary>
+    /// Error messages for any failed checks.
+    /// </summary>
+    public List<string> Errors { get; set; } = new();
+
+    /// <summary>
+    /// Verified claims organized by namespace and element identifier.
+    /// </summary>
+    public Dictionary<string, Dictionary<string, object>> VerifiedClaims { get; set; } = new();
+
+    /// <summary>
+    /// The verified Mobile Security Object.
+    /// </summary>
+    public MobileSecurityObject? MobileSecurityObject { get; set; }
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    /// <returns>A successful verification result.</returns>
+    public static MdocVerificationResult Success()
+    {
+        return new MdocVerificationResult
+        {
+            IsValid = true,
+            IssuerSignatureValid = true,
+            DigestsValid = true,
+            ValidityPeriodValid = true
+        };
+    }
+
+    /// <summary>
+    /// Creates a failed result with the specified error.
+    /// </summary>
+    /// <param name="error">The error message.</param>
+    /// <returns>A failed verification result.</returns>
+    public static MdocVerificationResult Failure(string error)
+    {
+        return new MdocVerificationResult
+        {
+            IsValid = false,
+            Errors = new List<string> { error }
+        };
+    }
+}

--- a/src/SdJwt.Net.Mdoc/Verifier/MdocVerifier.cs
+++ b/src/SdJwt.Net.Mdoc/Verifier/MdocVerifier.cs
@@ -1,0 +1,359 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using PeterO.Cbor;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Handover;
+using SdJwt.Net.Mdoc.Models;
+
+namespace SdJwt.Net.Mdoc.Verifier;
+
+/// <summary>
+/// Verifies mdoc credentials per ISO 18013-5.
+/// </summary>
+public class MdocVerifier
+{
+    private readonly MdocVerificationOptions _options;
+    private readonly ICoseCryptoProvider _cryptoProvider;
+
+    /// <summary>
+    /// Creates a new MdocVerifier with default options.
+    /// </summary>
+    public MdocVerifier() : this(new MdocVerificationOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a new MdocVerifier with the specified options.
+    /// </summary>
+    /// <param name="options">Verification options.</param>
+    public MdocVerifier(MdocVerificationOptions options)
+        : this(options, new DefaultCoseCryptoProvider())
+    {
+    }
+
+    /// <summary>
+    /// Creates a new MdocVerifier with custom crypto provider.
+    /// </summary>
+    /// <param name="options">Verification options.</param>
+    /// <param name="cryptoProvider">COSE crypto provider.</param>
+    public MdocVerifier(MdocVerificationOptions options, ICoseCryptoProvider cryptoProvider)
+    {
+        _options = options;
+        _cryptoProvider = cryptoProvider;
+    }
+
+    /// <summary>
+    /// Verifies a DeviceResponse.
+    /// </summary>
+    /// <param name="response">The device response to verify.</param>
+    /// <param name="sessionTranscript">Session transcript for device authentication.</param>
+    /// <returns>Verification result for each document.</returns>
+    public List<MdocVerificationResult> Verify(DeviceResponse response, SessionTranscript? sessionTranscript = null)
+    {
+        var results = new List<MdocVerificationResult>();
+
+        foreach (var doc in response.Documents)
+        {
+            results.Add(VerifyDocument(doc, sessionTranscript));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Verifies a Document.
+    /// </summary>
+    /// <param name="document">The document to verify.</param>
+    /// <param name="sessionTranscript">Session transcript for device authentication.</param>
+    /// <returns>Verification result.</returns>
+    public MdocVerificationResult VerifyDocument(Document document, SessionTranscript? sessionTranscript = null)
+    {
+        var result = new MdocVerificationResult();
+
+        // Check allowed doc types
+        if (_options.AllowedDocTypes.Count > 0 &&
+            !_options.AllowedDocTypes.Contains(document.DocType))
+        {
+            result.Errors.Add($"Document type '{document.DocType}' is not allowed.");
+            return result;
+        }
+
+        // Verify IssuerAuth signature
+        var issuerAuthResult = VerifyIssuerAuth(document.IssuerSigned);
+        if (!issuerAuthResult.IssuerSignatureValid)
+        {
+            result.Errors.AddRange(issuerAuthResult.Errors);
+            return result;
+        }
+
+        result.IssuerSignatureValid = true;
+        result.MobileSecurityObject = issuerAuthResult.MobileSecurityObject;
+
+        // Verify MSO docType matches Document docType
+        if (result.MobileSecurityObject?.DocType != document.DocType)
+        {
+            result.Errors.Add("MSO docType does not match Document docType.");
+            return result;
+        }
+
+        // Verify digests
+        var digestsValid = VerifyDigests(document, result.MobileSecurityObject);
+        result.DigestsValid = digestsValid;
+        if (!digestsValid)
+        {
+            result.Errors.Add("One or more value digests do not match.");
+            return result;
+        }
+
+        // Verify validity period
+        if (_options.VerifyValidity)
+        {
+            var validityValid = VerifyValidity(result.MobileSecurityObject);
+            result.ValidityPeriodValid = validityValid;
+            if (!validityValid)
+            {
+                result.Errors.Add("Credential is outside its validity period.");
+                return result;
+            }
+        }
+        else
+        {
+            result.ValidityPeriodValid = true;
+        }
+
+        // Verify device signature if present and required
+        if (_options.VerifyDeviceSignature &&
+            document.DeviceSigned?.DeviceAuth != null &&
+            sessionTranscript != null)
+        {
+            var deviceSigValid = VerifyDeviceSignature(
+                document,
+                result.MobileSecurityObject,
+                sessionTranscript);
+            result.DeviceSignatureValid = deviceSigValid;
+            if (!deviceSigValid)
+            {
+                result.Errors.Add("Device signature verification failed.");
+                return result;
+            }
+        }
+
+        // Extract verified claims
+        result.VerifiedClaims = ExtractClaims(document);
+        result.IsValid = true;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Verifies an IssuerSigned structure and extracts the MSO.
+    /// </summary>
+    /// <param name="issuerSigned">The issuer-signed data.</param>
+    /// <returns>Verification result with MSO.</returns>
+    public MdocVerificationResult VerifyIssuerAuth(IssuerSigned issuerSigned)
+    {
+        var result = new MdocVerificationResult();
+
+        if (issuerSigned.IssuerAuth == null || issuerSigned.IssuerAuth.Length == 0)
+        {
+            result.Errors.Add("IssuerAuth is missing.");
+            return result;
+        }
+
+        // Parse COSE_Sign1
+        CoseSign1 coseSign1;
+        try
+        {
+            coseSign1 = CoseSign1.FromCbor(issuerSigned.IssuerAuth);
+        }
+        catch (Exception ex)
+        {
+            result.Errors.Add($"Failed to parse IssuerAuth: {ex.Message}");
+            return result;
+        }
+
+        // Extract public key from x5chain
+        ECDsa? publicKey = null;
+        if (coseSign1.UnprotectedHeaders.TryGetValue("x5chain", out var x5chainObj) &&
+            x5chainObj is byte[] certBytes)
+        {
+            try
+            {
+                publicKey = LoadCertificatePublicKey(certBytes);
+            }
+            catch (Exception ex)
+            {
+                result.Errors.Add($"Failed to extract public key from certificate: {ex.Message}");
+                return result;
+            }
+        }
+
+        if (publicKey == null)
+        {
+            result.Errors.Add("No public key available for signature verification.");
+            return result;
+        }
+
+        // Verify signature
+        if (!_cryptoProvider.Verify(coseSign1, publicKey))
+        {
+            result.Errors.Add("Issuer signature verification failed.");
+            return result;
+        }
+
+        result.IssuerSignatureValid = true;
+
+        // Parse MSO
+        if (coseSign1.Payload == null || coseSign1.Payload.Length == 0)
+        {
+            result.Errors.Add("MSO payload is missing.");
+            return result;
+        }
+
+        try
+        {
+            result.MobileSecurityObject = MobileSecurityObject.FromCbor(coseSign1.Payload);
+        }
+        catch (Exception ex)
+        {
+            result.Errors.Add($"Failed to parse MSO: {ex.Message}");
+            return result;
+        }
+
+        return result;
+    }
+
+    private bool VerifyDigests(Document document, MobileSecurityObject mso)
+    {
+        foreach (var (nameSpace, items) in document.IssuerSigned.NameSpaces)
+        {
+            if (!mso.ValueDigests.TryGetValue(nameSpace, out var digestMapping))
+            {
+                return false;
+            }
+
+            foreach (var item in items)
+            {
+                if (!digestMapping.Digests.TryGetValue(item.DigestId, out var expectedDigest))
+                {
+                    return false;
+                }
+
+                // Compute digest of tagged item
+                var itemBytes = CBORObject.FromObjectAndTag(item.ToCbor(), 24).EncodeToBytes();
+                var actualDigest = ComputeSha256(itemBytes);
+
+                if (!CryptographicOperations.FixedTimeEquals(actualDigest, expectedDigest))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private bool VerifyValidity(MobileSecurityObject mso)
+    {
+        var now = _options.CurrentTime ?? DateTimeOffset.UtcNow;
+        var tolerance = _options.ClockSkewTolerance;
+
+        if (mso.ValidityInfo == null)
+        {
+            return false;
+        }
+
+        var validFrom = mso.ValidityInfo.ValidFrom;
+        var validUntil = mso.ValidityInfo.ValidUntil;
+
+        return now >= validFrom - tolerance && now <= validUntil + tolerance;
+    }
+
+    private bool VerifyDeviceSignature(
+        Document document,
+        MobileSecurityObject mso,
+        SessionTranscript sessionTranscript)
+    {
+        if (document.DeviceSigned?.DeviceAuth?.DeviceSignature == null)
+        {
+            return false;
+        }
+
+        if (mso.DeviceKeyInfo?.DeviceKey == null || mso.DeviceKeyInfo.DeviceKey.Length == 0)
+        {
+            return false;
+        }
+
+        // Parse device signature
+        CoseSign1 deviceSig;
+        try
+        {
+            deviceSig = CoseSign1.FromCbor(document.DeviceSigned.DeviceAuth.DeviceSignature);
+        }
+        catch
+        {
+            return false;
+        }
+
+        // Get device public key - DeviceKey is stored as CBOR-encoded CoseKey
+        ECDsa? deviceKey;
+        try
+        {
+            var coseKey = CoseKey.FromCbor(mso.DeviceKeyInfo.DeviceKey);
+            deviceKey = coseKey.ToECDsa();
+        }
+        catch
+        {
+            return false;
+        }
+
+        // Verify with external_aad = SessionTranscript
+        var externalAad = sessionTranscript.ToCbor();
+        return _cryptoProvider.Verify(deviceSig, deviceKey, externalAad);
+    }
+
+    private static Dictionary<string, Dictionary<string, object>> ExtractClaims(Document document)
+    {
+        var claims = new Dictionary<string, Dictionary<string, object>>();
+
+        foreach (var (nameSpace, items) in document.IssuerSigned.NameSpaces)
+        {
+            var nsClaims = new Dictionary<string, object>();
+            foreach (var item in items)
+            {
+                if (item.ElementValue != null)
+                {
+                    nsClaims[item.ElementIdentifier] = item.ElementValue;
+                }
+            }
+            claims[nameSpace] = nsClaims;
+        }
+
+        return claims;
+    }
+
+    private static ECDsa LoadCertificatePublicKey(byte[] certBytes)
+    {
+#if NET9_0_OR_GREATER
+        using var cert = X509CertificateLoader.LoadCertificate(certBytes);
+#else
+        using var cert = new X509Certificate2(certBytes);
+#endif
+        var publicKey = cert.GetECDsaPublicKey();
+        if (publicKey == null)
+        {
+            throw new InvalidOperationException("Certificate does not contain an ECDsa public key.");
+        }
+        return publicKey;
+    }
+
+    private static byte[] ComputeSha256(byte[] data)
+    {
+#if NETSTANDARD2_1
+        using var sha256 = SHA256.Create();
+        return sha256.ComputeHash(data);
+#else
+        return SHA256.HashData(data);
+#endif
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Cbor/CborSerializerTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Cbor/CborSerializerTests.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Cbor;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Cbor;
+
+/// <summary>
+/// Tests for CBOR serialization interface and utilities.
+/// </summary>
+public class CborSerializerTests
+{
+    [Fact]
+    public void Serialize_WithString_ReturnsCborBytes()
+    {
+        // Arrange
+        var value = "test string";
+
+        // Act
+        var result = CborUtils.SerializeString(value);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Serialize_WithByteArray_ReturnsCborBytes()
+    {
+        // Arrange
+        var value = new byte[] { 0x01, 0x02, 0x03 };
+
+        // Act
+        var result = CborUtils.SerializeBytes(value);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Deserialize_WithCborString_ReturnsString()
+    {
+        // Arrange
+        var original = "test string";
+        var cborData = CborUtils.SerializeString(original);
+
+        // Act
+        var result = CborUtils.DeserializeString(cborData);
+
+        // Assert
+        result.Should().Be(original);
+    }
+
+    [Fact]
+    public void Deserialize_WithCborBytes_ReturnsByteArray()
+    {
+        // Arrange
+        var original = new byte[] { 0x01, 0x02, 0x03 };
+        var cborData = CborUtils.SerializeBytes(original);
+
+        // Act
+        var result = CborUtils.DeserializeBytes(cborData);
+
+        // Assert
+        result.Should().BeEquivalentTo(original);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(42)]
+    [InlineData(-1)]
+    [InlineData(int.MaxValue)]
+    public void Serialize_WithInteger_RoundTrips(int value)
+    {
+        // Act
+        var cborData = CborUtils.SerializeInt(value);
+        var result = CborUtils.DeserializeInt(cborData);
+
+        // Assert
+        result.Should().Be(value);
+    }
+
+    [Fact]
+    public void Serialize_WithNullString_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => CborUtils.SerializeString(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Serialize_WithNullBytes_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => CborUtils.SerializeBytes(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Deserialize_WithNullData_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => CborUtils.DeserializeString(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Deserialize_WithEmptyData_ThrowsArgumentException()
+    {
+        // Act
+        var act = () => CborUtils.DeserializeString(Array.Empty<byte>());
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Serialize_WithDateTimeOffset_RoundTrips()
+    {
+        // Arrange
+        var value = new DateTimeOffset(2024, 6, 15, 12, 30, 45, TimeSpan.Zero);
+
+        // Act
+        var cborData = CborUtils.SerializeDateTimeOffset(value);
+        var result = CborUtils.DeserializeDateTimeOffset(cborData);
+
+        // Assert
+        result.Should().Be(value);
+    }
+
+    [Fact]
+    public void Serialize_WithBool_RoundTrips()
+    {
+        // Act
+        var trueData = CborUtils.SerializeBool(true);
+        var falseData = CborUtils.SerializeBool(false);
+        var trueResult = CborUtils.DeserializeBool(trueData);
+        var falseResult = CborUtils.DeserializeBool(falseData);
+
+        // Assert
+        trueResult.Should().BeTrue();
+        falseResult.Should().BeFalse();
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Cose/CoseAlgorithmTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Cose/CoseAlgorithmTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Cose;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Cose;
+
+/// <summary>
+/// Tests for COSE algorithm identifiers.
+/// </summary>
+public class CoseAlgorithmTests
+{
+    [Fact]
+    public void ES256_HasCorrectValue()
+    {
+        // Assert
+        ((int)CoseAlgorithm.ES256).Should().Be(-7);
+    }
+
+    [Fact]
+    public void ES384_HasCorrectValue()
+    {
+        // Assert
+        ((int)CoseAlgorithm.ES384).Should().Be(-35);
+    }
+
+    [Fact]
+    public void ES512_HasCorrectValue()
+    {
+        // Assert
+        ((int)CoseAlgorithm.ES512).Should().Be(-36);
+    }
+
+    [Fact]
+    public void EdDSA_HasCorrectValue()
+    {
+        // Assert
+        ((int)CoseAlgorithm.EdDSA).Should().Be(-8);
+    }
+
+    [Theory]
+    [InlineData(CoseAlgorithm.ES256, "SHA-256")]
+    [InlineData(CoseAlgorithm.ES384, "SHA-384")]
+    [InlineData(CoseAlgorithm.ES512, "SHA-512")]
+    public void GetDigestAlgorithm_ReturnsCorrectValue(CoseAlgorithm algorithm, string expectedDigest)
+    {
+        // Act
+        var result = algorithm.GetDigestAlgorithm();
+
+        // Assert
+        result.Should().Be(expectedDigest);
+    }
+
+    [Fact]
+    public void IsSupportedForHaip_WithES256_ReturnsTrue()
+    {
+        // Act
+        var result = CoseAlgorithm.ES256.IsSupportedForHaip();
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSupportedForHaip_WithES384_ReturnsTrue()
+    {
+        // Act
+        var result = CoseAlgorithm.ES384.IsSupportedForHaip();
+
+        // Assert
+        result.Should().BeTrue();
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Cose/CoseKeyTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Cose/CoseKeyTests.cs
@@ -1,0 +1,132 @@
+using System.Security.Cryptography;
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Cose;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Cose;
+
+/// <summary>
+/// Tests for COSE_Key representation.
+/// </summary>
+public class CoseKeyTests : IDisposable
+{
+    private readonly ECDsa _ecKeyP256;
+    private readonly ECDsa _ecKeyP384;
+
+    public CoseKeyTests()
+    {
+        _ecKeyP256 = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        _ecKeyP384 = ECDsa.Create(ECCurve.NamedCurves.nistP384);
+    }
+
+    [Fact]
+    public void FromECDsa_WithP256_CreatesValidCoseKey()
+    {
+        // Act
+        var coseKey = CoseKey.FromECDsa(_ecKeyP256);
+
+        // Assert
+        coseKey.Should().NotBeNull();
+        coseKey.KeyType.Should().Be(CoseKeyType.EC2);
+        coseKey.Curve.Should().Be(CoseCurve.P256);
+    }
+
+    [Fact]
+    public void FromECDsa_WithP384_CreatesValidCoseKey()
+    {
+        // Act
+        var coseKey = CoseKey.FromECDsa(_ecKeyP384);
+
+        // Assert
+        coseKey.Should().NotBeNull();
+        coseKey.KeyType.Should().Be(CoseKeyType.EC2);
+        coseKey.Curve.Should().Be(CoseCurve.P384);
+    }
+
+    [Fact]
+    public void FromECDsa_WithNull_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => CoseKey.FromECDsa(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ToCbor_ReturnsValidCborBytes()
+    {
+        // Arrange
+        var coseKey = CoseKey.FromECDsa(_ecKeyP256);
+
+        // Act
+        var cborBytes = coseKey.ToCbor();
+
+        // Assert
+        cborBytes.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void FromCbor_WithValidData_CreatesCoseKey()
+    {
+        // Arrange
+        var originalKey = CoseKey.FromECDsa(_ecKeyP256);
+        var cborBytes = originalKey.ToCbor();
+
+        // Act
+        var restoredKey = CoseKey.FromCbor(cborBytes);
+
+        // Assert
+        restoredKey.Should().NotBeNull();
+        restoredKey.KeyType.Should().Be(originalKey.KeyType);
+        restoredKey.Curve.Should().Be(originalKey.Curve);
+    }
+
+    [Fact]
+    public void HasPrivateKey_WithPrivateKey_ReturnsTrue()
+    {
+        // Arrange
+        var coseKey = CoseKey.FromECDsa(_ecKeyP256);
+
+        // Act & Assert
+        coseKey.HasPrivateKey.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetPublicKey_ReturnsOnlyPublicPortion()
+    {
+        // Arrange
+        var coseKey = CoseKey.FromECDsa(_ecKeyP256);
+
+        // Act
+        var publicKey = coseKey.GetPublicKey();
+
+        // Assert
+        publicKey.HasPrivateKey.Should().BeFalse();
+        publicKey.X.Should().BeEquivalentTo(coseKey.X);
+        publicKey.Y.Should().BeEquivalentTo(coseKey.Y);
+    }
+
+    [Fact]
+    public void ToECDsa_ReturnsEquivalentKey()
+    {
+        // Arrange
+        var coseKey = CoseKey.FromECDsa(_ecKeyP256);
+
+        // Act
+        using var ecDsa = coseKey.ToECDsa();
+
+        // Assert
+        ecDsa.Should().NotBeNull();
+        var exportedParams = ecDsa.ExportParameters(false);
+        exportedParams.Q.X.Should().BeEquivalentTo(coseKey.X);
+        exportedParams.Q.Y.Should().BeEquivalentTo(coseKey.Y);
+    }
+
+    public void Dispose()
+    {
+        _ecKeyP256.Dispose();
+        _ecKeyP384.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Cose/CoseSign1Tests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Cose/CoseSign1Tests.cs
@@ -1,0 +1,192 @@
+using System.Security.Cryptography;
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Cose;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Cose;
+
+/// <summary>
+/// Tests for COSE_Sign1 structure (RFC 8152).
+/// </summary>
+public class CoseSign1Tests : IDisposable
+{
+    private readonly ECDsa _signingKey;
+    private readonly ICoseCryptoProvider _cryptoProvider;
+
+    public CoseSign1Tests()
+    {
+        _signingKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        _cryptoProvider = new DefaultCoseCryptoProvider();
+    }
+
+    [Fact]
+    public async Task Sign_WithValidPayload_ReturnsSignature()
+    {
+        // Arrange
+        var payload = new byte[] { 0x01, 0x02, 0x03 };
+        var coseKey = CoseKey.FromECDsa(_signingKey);
+
+        // Act
+        var coseSign1 = await CoseSign1.CreateAsync(
+            payload,
+            coseKey,
+            CoseAlgorithm.ES256,
+            _cryptoProvider);
+
+        // Assert
+        coseSign1.Should().NotBeNull();
+        coseSign1.Payload.Should().BeEquivalentTo(payload);
+        coseSign1.Signature.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Verify_WithValidSignature_ReturnsTrue()
+    {
+        // Arrange
+        var payload = new byte[] { 0x01, 0x02, 0x03 };
+        var coseKey = CoseKey.FromECDsa(_signingKey);
+
+        var coseSign1 = await CoseSign1.CreateAsync(
+            payload,
+            coseKey,
+            CoseAlgorithm.ES256,
+            _cryptoProvider);
+
+        // Act
+        var result = await coseSign1.VerifyAsync(coseKey.GetPublicKey(), _cryptoProvider);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Verify_WithWrongKey_ReturnsFalse()
+    {
+        // Arrange
+        var payload = new byte[] { 0x01, 0x02, 0x03 };
+        var coseKey = CoseKey.FromECDsa(_signingKey);
+
+        var coseSign1 = await CoseSign1.CreateAsync(
+            payload,
+            coseKey,
+            CoseAlgorithm.ES256,
+            _cryptoProvider);
+
+        using var differentKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var wrongKey = CoseKey.FromECDsa(differentKey);
+
+        // Act
+        var result = await coseSign1.VerifyAsync(wrongKey.GetPublicKey(), _cryptoProvider);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ToCbor_ReturnsValidCborEncoding()
+    {
+        // Arrange
+        var payload = new byte[] { 0x01, 0x02, 0x03 };
+        var coseKey = CoseKey.FromECDsa(_signingKey);
+
+        var coseSign1 = await CoseSign1.CreateAsync(
+            payload,
+            coseKey,
+            CoseAlgorithm.ES256,
+            _cryptoProvider);
+
+        // Act
+        var cborBytes = coseSign1.ToCbor();
+
+        // Assert
+        cborBytes.Should().NotBeNullOrEmpty();
+        // COSE_Sign1 is tagged with 18
+        cborBytes[0].Should().Be(0xD2); // Tag 18 in CBOR
+    }
+
+    [Fact]
+    public async Task FromCbor_WithValidData_RestoresCoseSign1()
+    {
+        // Arrange
+        var payload = new byte[] { 0x01, 0x02, 0x03 };
+        var coseKey = CoseKey.FromECDsa(_signingKey);
+
+        var original = await CoseSign1.CreateAsync(
+            payload,
+            coseKey,
+            CoseAlgorithm.ES256,
+            _cryptoProvider);
+
+        var cborBytes = original.ToCbor();
+
+        // Act
+        var restored = CoseSign1.FromCbor(cborBytes);
+
+        // Assert
+        restored.Should().NotBeNull();
+        restored.Payload.Should().BeEquivalentTo(original.Payload);
+        restored.Signature.Should().BeEquivalentTo(original.Signature);
+    }
+
+    [Fact]
+    public async Task Create_WithExternalAad_IncludesInSignature()
+    {
+        // Arrange
+        var payload = new byte[] { 0x01, 0x02, 0x03 };
+        var externalAad = new byte[] { 0xAA, 0xBB, 0xCC };
+        var coseKey = CoseKey.FromECDsa(_signingKey);
+
+        // Act
+        var coseSign1 = await CoseSign1.CreateAsync(
+            payload,
+            coseKey,
+            CoseAlgorithm.ES256,
+            _cryptoProvider,
+            externalAad: externalAad);
+
+        // Assert - Signature should verify only with same AAD
+        var result = await coseSign1.VerifyAsync(coseKey.GetPublicKey(), _cryptoProvider, externalAad);
+        result.Should().BeTrue();
+
+        // Different AAD should fail verification
+        var resultWithWrongAad = await coseSign1.VerifyAsync(
+            coseKey.GetPublicKey(),
+            _cryptoProvider,
+            new byte[] { 0x11, 0x22 });
+        resultWithWrongAad.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Create_WithNullPayload_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = async () => await CoseSign1.CreateAsync(
+            null!,
+            CoseKey.FromECDsa(_signingKey),
+            CoseAlgorithm.ES256,
+            _cryptoProvider);
+
+        // Assert
+        act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Create_WithNullKey_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = async () => await CoseSign1.CreateAsync(
+            new byte[] { 0x01 },
+            null!,
+            CoseAlgorithm.ES256,
+            _cryptoProvider);
+
+        // Assert
+        act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    public void Dispose()
+    {
+        _signingKey.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Handover/OpenId4VpHandoverTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Handover/OpenId4VpHandoverTests.cs
@@ -1,0 +1,133 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Handover;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Handover;
+
+/// <summary>
+/// Tests for OpenID4VP Handover structure per OpenID4VP Appendix B.2.
+/// </summary>
+public class OpenId4VpHandoverTests
+{
+    [Fact]
+    public void Create_WithValidParameters_ReturnsHandover()
+    {
+        // Arrange
+        var clientId = "https://verifier.example.com";
+        var responseUri = "https://verifier.example.com/callback";
+        var nonce = "n-0S6_WzA2Mj";
+        var mdocGeneratedNonce = "mdoc-nonce-123";
+
+        // Act
+        var handover = OpenId4VpHandover.Create(clientId, responseUri, nonce, mdocGeneratedNonce);
+
+        // Assert
+        handover.Should().NotBeNull();
+        handover.ClientId.Should().Be(clientId);
+        handover.ResponseUri.Should().Be(responseUri);
+        handover.Nonce.Should().Be(nonce);
+        handover.MdocGeneratedNonce.Should().Be(mdocGeneratedNonce);
+    }
+
+    [Fact]
+    public void Create_WithEmptyMdocGeneratedNonce_CreatesHandover()
+    {
+        // Arrange
+        var clientId = "https://verifier.example.com";
+        var responseUri = "https://verifier.example.com/callback";
+        var nonce = "n-0S6_WzA2Mj";
+
+        // Act
+        var handover = OpenId4VpHandover.Create(clientId, responseUri, nonce, string.Empty);
+
+        // Assert
+        handover.Should().NotBeNull();
+        handover.MdocGeneratedNonce.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToCbor_ReturnsValidCborArray()
+    {
+        // Arrange
+        var handover = OpenId4VpHandover.Create(
+            "client123",
+            "https://response.uri",
+            "nonce456",
+            "mdoc-nonce");
+
+        // Act
+        var cborBytes = handover.ToCbor();
+
+        // Assert
+        cborBytes.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void ToCborObject_ReturnsNonNull()
+    {
+        // Arrange
+        var handover = OpenId4VpHandover.Create(
+            "client123",
+            "https://response.uri",
+            "nonce456",
+            "mdoc-nonce");
+
+        // Act
+        var cborObject = handover.ToCborObject();
+
+        // Assert
+        cborObject.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CreateSessionTranscript_ReturnsTranscriptWithHandover()
+    {
+        // Arrange
+        var handover = OpenId4VpHandover.Create(
+            "client123",
+            "https://response.uri",
+            "nonce456",
+            "mdoc-nonce");
+
+        // Act
+        var transcript = handover.CreateSessionTranscript();
+
+        // Assert
+        transcript.Should().NotBeNull();
+        transcript.Handover.Should().BeSameAs(handover);
+        transcript.DeviceEngagement.Should().BeNull();
+        transcript.EReaderKeyPub.Should().BeNull();
+    }
+
+    [Fact]
+    public void Properties_DefaultValues_AreEmpty()
+    {
+        // Act
+        var handover = new OpenId4VpHandover();
+
+        // Assert
+        handover.ClientId.Should().BeEmpty();
+        handover.ResponseUri.Should().BeEmpty();
+        handover.Nonce.Should().BeEmpty();
+        handover.MdocGeneratedNonce.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Properties_CanBeSet()
+    {
+        // Arrange
+        var handover = new OpenId4VpHandover
+        {
+            ClientId = "test-client",
+            ResponseUri = "https://test.uri",
+            Nonce = "test-nonce",
+            MdocGeneratedNonce = "mdoc-nonce"
+        };
+
+        // Assert
+        handover.ClientId.Should().Be("test-client");
+        handover.ResponseUri.Should().Be("https://test.uri");
+        handover.Nonce.Should().Be("test-nonce");
+        handover.MdocGeneratedNonce.Should().Be("mdoc-nonce");
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Handover/SessionTranscriptTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Handover/SessionTranscriptTests.cs
@@ -1,0 +1,158 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Handover;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Handover;
+
+/// <summary>
+/// Tests for SessionTranscript structure for OpenID4VP mdoc presentations.
+/// </summary>
+public class SessionTranscriptTests
+{
+    [Fact]
+    public void ForOpenId4Vp_CreatesValidTranscript()
+    {
+        // Arrange
+        var clientId = "https://verifier.example.com";
+        var nonce = "n-0S6_WzA2Mj";
+        var responseUri = "https://verifier.example.com/callback";
+
+        // Act
+        var transcript = SessionTranscript.ForOpenId4Vp(clientId, nonce, null, responseUri);
+
+        // Assert
+        transcript.Should().NotBeNull();
+        transcript.DeviceEngagement.Should().BeNull();
+        transcript.EReaderKeyPub.Should().BeNull();
+        transcript.Handover.Should().NotBeNull();
+        transcript.Handover.Should().BeOfType<OpenId4VpHandover>();
+    }
+
+    [Fact]
+    public void ForOpenId4Vp_WithMdocGeneratedNonce_IncludesInHandover()
+    {
+        // Arrange
+        var clientId = "https://verifier.example.com";
+        var nonce = "n-0S6_WzA2Mj";
+        var mdocGeneratedNonce = "mdoc-generated-nonce";
+        var responseUri = "https://verifier.example.com/callback";
+
+        // Act
+        var transcript = SessionTranscript.ForOpenId4Vp(clientId, nonce, mdocGeneratedNonce, responseUri);
+
+        // Assert
+        transcript.Handover.Should().BeOfType<OpenId4VpHandover>();
+        var handover = (OpenId4VpHandover)transcript.Handover!;
+        handover.MdocGeneratedNonce.Should().Be(mdocGeneratedNonce);
+    }
+
+    [Fact]
+    public void ForOpenId4VpDcApi_CreatesValidTranscript()
+    {
+        // Arrange
+        var origin = "https://verifier.example.com";
+        var nonce = "n-0S6_WzA2Mj";
+
+        // Act
+        var transcript = SessionTranscript.ForOpenId4VpDcApi(origin, nonce, null);
+
+        // Assert
+        transcript.Should().NotBeNull();
+        transcript.DeviceEngagement.Should().BeNull();
+        transcript.EReaderKeyPub.Should().BeNull();
+        transcript.Handover.Should().BeOfType<OpenId4VpDcApiHandover>();
+    }
+
+    [Fact]
+    public void ToCbor_ReturnsValidCborArray()
+    {
+        // Arrange
+        var transcript = SessionTranscript.ForOpenId4Vp(
+            "client123",
+            "nonce456",
+            null,
+            "https://response.uri");
+
+        // Act
+        var cborBytes = transcript.ToCbor();
+
+        // Assert
+        cborBytes.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void FromCbor_WithValidData_RestoresTranscript()
+    {
+        // Arrange
+        var original = SessionTranscript.ForOpenId4Vp(
+            "client123",
+            "nonce456",
+            null,
+            "https://response.uri");
+
+        var cborBytes = original.ToCbor();
+
+        // Act
+        var restored = SessionTranscript.FromCbor(cborBytes);
+
+        // Assert
+        restored.Should().NotBeNull();
+        restored.DeviceEngagement.Should().BeNull();
+        restored.EReaderKeyPub.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_CreatesEmptyTranscript()
+    {
+        // Act
+        var transcript = new SessionTranscript();
+
+        // Assert
+        transcript.DeviceEngagement.Should().BeNull();
+        transcript.EReaderKeyPub.Should().BeNull();
+        transcript.Handover.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCborObject_ReturnsNonNull()
+    {
+        // Arrange
+        var transcript = SessionTranscript.ForOpenId4Vp(
+            "client123",
+            "nonce456",
+            null,
+            "https://response.uri");
+
+        // Act
+        var cborObject = transcript.ToCborObject();
+
+        // Assert
+        cborObject.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void DeviceEngagement_WhenSet_CanBeRetrieved()
+    {
+        // Arrange
+        var transcript = new SessionTranscript
+        {
+            DeviceEngagement = new byte[] { 0x01, 0x02, 0x03 }
+        };
+
+        // Assert
+        transcript.DeviceEngagement.Should().BeEquivalentTo(new byte[] { 0x01, 0x02, 0x03 });
+    }
+
+    [Fact]
+    public void EReaderKeyPub_WhenSet_CanBeRetrieved()
+    {
+        // Arrange
+        var transcript = new SessionTranscript
+        {
+            EReaderKeyPub = new byte[] { 0x04, 0x05, 0x06 }
+        };
+
+        // Assert
+        transcript.EReaderKeyPub.Should().BeEquivalentTo(new byte[] { 0x04, 0x05, 0x06 });
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Integration/EndToEndTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Integration/EndToEndTests.cs
@@ -1,0 +1,276 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Handover;
+using SdJwt.Net.Mdoc.Issuer;
+using SdJwt.Net.Mdoc.Models;
+using SdJwt.Net.Mdoc.Namespaces;
+using SdJwt.Net.Mdoc.Verifier;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Integration;
+
+/// <summary>
+/// End-to-end integration tests for mdoc issuance, presentation, and verification.
+/// </summary>
+public class EndToEndTests : TestBase
+{
+    private readonly ICoseCryptoProvider _cryptoProvider;
+
+    public EndToEndTests()
+    {
+        _cryptoProvider = new DefaultCoseCryptoProvider();
+    }
+
+    [Fact]
+    public async Task Issue_WithValidClaims_CreatesSignedMdoc()
+    {
+        // Arrange
+        var issuerCoseKey = CoseKey.FromECDsa(IssuerSigningKey);
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var mdoc = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(issuerCoseKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+            .AddMdlElement(MdlDataElement.GivenName, "John")
+            .AddMdlElement(MdlDataElement.BirthDate, "1990-01-15")
+            .AddMdlElement(MdlDataElement.IssueDate, "2024-01-01")
+            .AddMdlElement(MdlDataElement.ExpiryDate, "2029-01-01")
+            .AddMdlElement(MdlDataElement.IssuingCountry, "US")
+            .AddMdlElement(MdlDataElement.IssuingAuthority, "State DMV")
+            .AddMdlElement(MdlDataElement.DocumentNumber, "DL123456789")
+            .AddMdlElement(MdlDataElement.AgeOver18, true)
+            .AddMdlElement(MdlDataElement.AgeOver21, true)
+            .WithValidity(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(_cryptoProvider);
+
+        // Assert
+        mdoc.Should().NotBeNull();
+        mdoc.DocType.Should().Be(MdlDocType);
+        mdoc.IssuerSigned.Should().NotBeNull();
+        mdoc.IssuerSigned.IssuerAuth.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Issue_WithMinimalClaims_Succeeds()
+    {
+        // Arrange
+        var issuerCoseKey = CoseKey.FromECDsa(IssuerSigningKey);
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var mdoc = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(issuerCoseKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1))
+            .BuildAsync(_cryptoProvider);
+
+        // Assert
+        mdoc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Build_WithoutDocType_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var issuerCoseKey = CoseKey.FromECDsa(IssuerSigningKey);
+
+        // Act
+        var act = () => new MdocIssuerBuilder()
+            .WithIssuerKey(issuerCoseKey)
+            .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+            .Build();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*DocType*");
+    }
+
+    [Fact]
+    public void Build_WithoutIssuerKey_ThrowsInvalidOperationException()
+    {
+        // Act
+        var act = () => new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+            .Build();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*key*");
+    }
+
+    [Fact]
+    public void SessionTranscript_ForOpenId4Vp_CreatesCorrectStructure()
+    {
+        // Act
+        var transcript = SessionTranscript.ForOpenId4Vp(
+            "https://verifier.example.com",
+            "nonce123",
+            null,
+            "https://verifier.example.com/callback");
+
+        // Assert
+        transcript.Should().NotBeNull();
+        transcript.DeviceEngagement.Should().BeNull();
+        transcript.EReaderKeyPub.Should().BeNull();
+        transcript.Handover.Should().NotBeNull();
+        transcript.Handover.Should().BeOfType<OpenId4VpHandover>();
+    }
+
+    [Fact]
+    public void SessionTranscript_ForOpenId4VpDcApi_CreatesCorrectStructure()
+    {
+        // Act
+        var transcript = SessionTranscript.ForOpenId4VpDcApi(
+            "https://verifier.example.com",
+            "nonce123",
+            null);
+
+        // Assert
+        transcript.Should().NotBeNull();
+        transcript.DeviceEngagement.Should().BeNull();
+        transcript.EReaderKeyPub.Should().BeNull();
+        transcript.Handover.Should().NotBeNull();
+        transcript.Handover.Should().BeOfType<OpenId4VpDcApiHandover>();
+    }
+
+    [Fact]
+    public void SessionTranscript_ToCbor_ProducesValidCbor()
+    {
+        // Arrange
+        var transcript = SessionTranscript.ForOpenId4Vp(
+            "https://verifier.example.com",
+            "nonce123",
+            null,
+            "https://verifier.example.com/callback");
+
+        // Act
+        var cbor = transcript.ToCbor();
+
+        // Assert
+        cbor.Should().NotBeNull();
+        cbor.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task IssuerSigned_ContainsNameSpaces()
+    {
+        // Arrange
+        var issuerCoseKey = CoseKey.FromECDsa(IssuerSigningKey);
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var mdoc = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(issuerCoseKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+            .AddMdlElement(MdlDataElement.GivenName, "John")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1))
+            .BuildAsync(_cryptoProvider);
+
+        // Assert
+        mdoc.IssuerSigned.NameSpaces.Should().NotBeNull();
+        mdoc.IssuerSigned.NameSpaces.Should().ContainKey(MdlNamespace);
+    }
+
+    [Fact]
+    public async Task IssuerAuth_HasValidSignature()
+    {
+        // Arrange
+        var issuerCoseKey = CoseKey.FromECDsa(IssuerSigningKey);
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var mdoc = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(issuerCoseKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1))
+            .BuildAsync(_cryptoProvider);
+
+        // Assert - IssuerAuth is COSE_Sign1 bytes
+        mdoc.IssuerSigned.IssuerAuth.Should().NotBeNull();
+        mdoc.IssuerSigned.IssuerAuth.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void CoseKey_FromECDsa_CreatesValidKey()
+    {
+        // Act
+        var coseKey = CoseKey.FromECDsa(IssuerSigningKey);
+
+        // Assert
+        coseKey.Should().NotBeNull();
+        coseKey.KeyType.Should().Be(CoseKeyType.EC2);
+    }
+
+    [Fact]
+    public void CoseKey_RoundTrip_PreservesKey()
+    {
+        // Arrange
+        var original = CoseKey.FromECDsa(IssuerSigningKey);
+
+        // Act
+        var cbor = original.ToCbor();
+        var restored = CoseKey.FromCbor(cbor);
+
+        // Assert
+        restored.KeyType.Should().Be(original.KeyType);
+        restored.X.Should().Equal(original.X);
+        restored.Y.Should().Equal(original.Y);
+    }
+
+    [Fact]
+    public async Task Document_ToCbor_ProducesValidCbor()
+    {
+        // Arrange
+        var issuerCoseKey = CoseKey.FromECDsa(IssuerSigningKey);
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        var mdoc = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(issuerCoseKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1))
+            .BuildAsync(_cryptoProvider);
+
+        // Act
+        var cbor = mdoc.ToCbor();
+
+        // Assert
+        cbor.Should().NotBeNull();
+        cbor.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Document_RoundTrip_PreservesData()
+    {
+        // Arrange
+        var issuerCoseKey = CoseKey.FromECDsa(IssuerSigningKey);
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        var original = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(issuerCoseKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1))
+            .BuildAsync(_cryptoProvider);
+
+        // Act
+        var cbor = original.ToCbor();
+        var restored = Document.FromCborObject(PeterO.Cbor.CBORObject.DecodeFromBytes(cbor));
+
+        // Assert
+        restored.DocType.Should().Be(original.DocType);
+        restored.IssuerSigned.NameSpaces.Should().ContainKey(MdlNamespace);
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Issuer/MdocIssuerBuilderTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Issuer/MdocIssuerBuilderTests.cs
@@ -1,0 +1,249 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Issuer;
+using SdJwt.Net.Mdoc.Namespaces;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Issuer;
+
+/// <summary>
+/// Tests for MdocIssuerBuilder fluent API.
+/// </summary>
+public class MdocIssuerBuilderTests : TestBase
+{
+    [Fact]
+    public async Task Build_WithMinimalConfiguration_CreatesMdoc()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        // Assert
+        document.Should().NotBeNull();
+        document.DocType.Should().Be(MdlDocType);
+    }
+
+    [Fact]
+    public async Task Build_WithMultipleClaims_IncludesAllClaims()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .AddClaim(MdlNamespace, "given_name", "John")
+            .AddClaim(MdlNamespace, "birth_date", "1990-01-15")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        // Assert
+        document.IssuerSigned.NameSpaces[MdlNamespace].Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task Build_WithMdlDataElement_UsesCorrectIdentifier()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddMdlElement(MdlDataElement.FamilyName, "Doe")
+            .AddMdlElement(MdlDataElement.GivenName, "John")
+            .AddMdlElement(MdlDataElement.AgeOver18, true)
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        // Assert
+        var elements = document.IssuerSigned.NameSpaces[MdlNamespace];
+        elements.Should().Contain(e => e.ElementIdentifier == "family_name");
+        elements.Should().Contain(e => e.ElementIdentifier == "given_name");
+        elements.Should().Contain(e => e.ElementIdentifier == "age_over_18");
+    }
+
+    [Fact]
+    public void Build_WithoutIssuerKey_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var act = () => new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithDeviceKey(deviceCoseKey)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .Build();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Build_WithoutDocType_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var act = () => new MdocIssuerBuilder()
+            .WithIssuerKey(IssuerSigningKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .Build();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Build_WithES384Algorithm_UsesCorrectAlgorithm()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKeyEs384)
+            .WithDeviceKey(deviceCoseKey)
+            .WithAlgorithm(CoseAlgorithm.ES384)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        // Assert
+        document.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void WithDocType_ChainsMethods()
+    {
+        // Arrange
+        var builder = new MdocIssuerBuilder();
+
+        // Act
+        var result = builder.WithDocType(MdlDocType);
+
+        // Assert
+        result.Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public void AddClaim_ChainsMethods()
+    {
+        // Arrange
+        var builder = new MdocIssuerBuilder();
+
+        // Act
+        var result = builder.AddClaim(MdlNamespace, "test", "value");
+
+        // Assert
+        result.Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public async Task Build_WithMultipleNamespaces_IncludesBothNamespaces()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+        var customNamespace = "com.example.custom";
+
+        // Act
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .AddClaim(customNamespace, "custom_field", "custom_value")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        // Assert
+        document.IssuerSigned.NameSpaces.Should().ContainKey(MdlNamespace);
+        document.IssuerSigned.NameSpaces.Should().ContainKey(customNamespace);
+    }
+
+    [Fact]
+    public void WithIssuerKey_WithCoseKey_ChainsMethods()
+    {
+        // Arrange
+        var builder = new MdocIssuerBuilder();
+        var coseKey = CoseKey.FromECDsa(IssuerSigningKey);
+
+        // Act
+        var result = builder.WithIssuerKey(coseKey);
+
+        // Assert
+        result.Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public void WithAlgorithm_ChainsMethods()
+    {
+        // Arrange
+        var builder = new MdocIssuerBuilder();
+
+        // Act
+        var result = builder.WithAlgorithm(CoseAlgorithm.ES256);
+
+        // Assert
+        result.Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public void WithDeviceKey_ChainsMethods()
+    {
+        // Arrange
+        var builder = new MdocIssuerBuilder();
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var result = builder.WithDeviceKey(deviceCoseKey);
+
+        // Assert
+        result.Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public void WithValidity_ChainsMethods()
+    {
+        // Arrange
+        var builder = new MdocIssuerBuilder();
+
+        // Act
+        var result = builder.WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1));
+
+        // Assert
+        result.Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public void AddMdlElement_ChainsMethods()
+    {
+        // Arrange
+        var builder = new MdocIssuerBuilder();
+
+        // Act
+        var result = builder.AddMdlElement(MdlDataElement.FamilyName, "Doe");
+
+        // Assert
+        result.Should().BeSameAs(builder);
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Issuer/MdocIssuerTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Issuer/MdocIssuerTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Issuer;
+using SdJwt.Net.Mdoc.Namespaces;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Issuer;
+
+/// <summary>
+/// Tests for MdocIssuer credential issuance.
+/// </summary>
+public class MdocIssuerTests : TestBase
+{
+    [Fact]
+    public async Task IssueAsync_WithValidConfiguration_CreatesSignedMdoc()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .AddClaim(MdlNamespace, "given_name", "John")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        // Assert
+        document.Should().NotBeNull();
+        document.DocType.Should().Be(MdlDocType);
+        document.IssuerSigned.Should().NotBeNull();
+        document.IssuerSigned.IssuerAuth.Should().NotBeNullOrEmpty();
+        document.IssuerSigned.NameSpaces.Should().ContainKey(MdlNamespace);
+    }
+
+    [Fact]
+    public void Issue_WithValidConfiguration_CreatesSignedMdoc()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        var issuer = new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .Build();
+
+        // Act
+        var issuerSigned = issuer.Issue();
+
+        // Assert
+        issuerSigned.Should().NotBeNull();
+        issuerSigned.IssuerAuth.Should().NotBeNullOrEmpty();
+        issuerSigned.NameSpaces.Should().ContainKey(MdlNamespace);
+    }
+
+    [Fact]
+    public void Build_WithoutIssuerKey_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var act = () => new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithDeviceKey(deviceCoseKey)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .Build();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Build_WithoutDocType_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var act = () => new MdocIssuerBuilder()
+            .WithIssuerKey(IssuerSigningKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .Build();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task IssueAsync_WithDataElements_ComputesDigests()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithDeviceKey(deviceCoseKey)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .AddClaim(MdlNamespace, "given_name", "John")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        // Assert
+        document.IssuerSigned.NameSpaces[MdlNamespace].Should().HaveCount(2);
+        document.IssuerSigned.NameSpaces[MdlNamespace]
+            .All(item => item.Random != null && item.Random.Length > 0)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IssueAsync_WithES384Algorithm_CreatesDocument()
+    {
+        // Arrange
+        var deviceCoseKey = CoseKey.FromECDsa(DeviceKey);
+
+        // Act
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKeyEs384)
+            .WithDeviceKey(deviceCoseKey)
+            .WithAlgorithm(CoseAlgorithm.ES384)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        // Assert
+        document.Should().NotBeNull();
+        document.IssuerSigned.IssuerAuth.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void CreateBuilder_ReturnsNewBuilder()
+    {
+        // Act
+        var builder = MdocIssuer.CreateBuilder();
+
+        // Assert
+        builder.Should().NotBeNull();
+        builder.Should().BeOfType<MdocIssuerBuilder>();
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Models/DeviceResponseTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Models/DeviceResponseTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Models;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Models;
+
+/// <summary>
+/// Tests for DeviceResponse structure per ISO 18013-5 Section 8.3.2.1.2.2.
+/// </summary>
+public class DeviceResponseTests
+{
+    [Fact]
+    public void Constructor_CreatesDefaultValues()
+    {
+        // Act
+        var response = new DeviceResponse();
+
+        // Assert
+        response.Version.Should().Be("1.0");
+        response.Documents.Should().NotBeNull();
+        response.Documents.Should().BeEmpty();
+        response.Status.Should().Be(0);
+    }
+
+    [Fact]
+    public void AddDocument_IncreasesCount()
+    {
+        // Arrange
+        var response = new DeviceResponse();
+        var document = new Document { DocType = "org.iso.18013.5.1.mDL" };
+
+        // Act
+        response.Documents.Add(document);
+
+        // Assert
+        response.Documents.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Status_Zero_IndicatesSuccess()
+    {
+        // Arrange
+        var response = new DeviceResponse { Status = 0 };
+
+        // Assert
+        response.Status.Should().Be(0);
+    }
+
+    [Fact]
+    public void Status_NonZero_IndicatesError()
+    {
+        // Arrange
+        var response = new DeviceResponse { Status = 10 };
+
+        // Assert
+        response.Status.Should().Be(10);
+    }
+
+    [Fact]
+    public void DocumentErrors_WhenSet_StoresCorrectly()
+    {
+        // Arrange
+        var response = new DeviceResponse();
+        var error = new DocumentError
+        {
+            DocType = "org.iso.18013.5.1.mDL",
+            ErrorCode = 1
+        };
+
+        // Act
+        response.DocumentErrors = new List<DocumentError> { error };
+
+        // Assert
+        response.DocumentErrors.Should().HaveCount(1);
+        response.DocumentErrors![0].DocType.Should().Be("org.iso.18013.5.1.mDL");
+    }
+
+    [Fact]
+    public void ToCbor_WithDocuments_ReturnsValidCborBytes()
+    {
+        // Arrange
+        var response = new DeviceResponse();
+        response.Documents.Add(new Document
+        {
+            DocType = "org.iso.18013.5.1.mDL",
+            IssuerSigned = new IssuerSigned()
+        });
+
+        // Act
+        var cborBytes = response.ToCbor();
+
+        // Assert
+        cborBytes.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void FromCbor_WithValidData_RestoresDeviceResponse()
+    {
+        // Arrange
+        var original = new DeviceResponse();
+        original.Documents.Add(new Document
+        {
+            DocType = "org.iso.18013.5.1.mDL",
+            IssuerSigned = new IssuerSigned()
+        });
+
+        var cborBytes = original.ToCbor();
+
+        // Act
+        var restored = DeviceResponse.FromCbor(cborBytes);
+
+        // Assert
+        restored.Version.Should().Be(original.Version);
+        restored.Documents.Should().HaveCount(1);
+        restored.Documents[0].DocType.Should().Be("org.iso.18013.5.1.mDL");
+    }
+
+    [Fact]
+    public void Version_CanBeSet()
+    {
+        // Arrange
+        var response = new DeviceResponse { Version = "2.0" };
+
+        // Assert
+        response.Version.Should().Be("2.0");
+    }
+
+    [Fact]
+    public void ToCborObject_ReturnsNonNull()
+    {
+        // Arrange
+        var response = new DeviceResponse();
+
+        // Act
+        var cborObject = response.ToCborObject();
+
+        // Assert
+        cborObject.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void DocumentErrors_DefaultIsNull()
+    {
+        // Act
+        var response = new DeviceResponse();
+
+        // Assert
+        response.DocumentErrors.Should().BeNull();
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Models/IssuerSignedTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Models/IssuerSignedTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Models;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Models;
+
+/// <summary>
+/// Tests for IssuerSigned structure.
+/// </summary>
+public class IssuerSignedTests
+{
+    [Fact]
+    public void Constructor_CreatesEmptyNameSpaces()
+    {
+        // Act
+        var issuerSigned = new IssuerSigned();
+
+        // Assert
+        issuerSigned.NameSpaces.Should().NotBeNull();
+        issuerSigned.NameSpaces.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddNameSpace_StoresItems()
+    {
+        // Arrange
+        var issuerSigned = new IssuerSigned();
+        var items = new List<IssuerSignedItem>
+        {
+            new()
+            {
+                DigestId = 0,
+                ElementIdentifier = "family_name",
+                ElementValue = "Doe"
+            }
+        };
+
+        // Act
+        issuerSigned.NameSpaces["org.iso.18013.5.1"] = items;
+
+        // Assert
+        issuerSigned.NameSpaces.Should().ContainKey("org.iso.18013.5.1");
+        issuerSigned.NameSpaces["org.iso.18013.5.1"].Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void IssuerAuth_WhenSet_StoresCoseSign1()
+    {
+        // Arrange
+        var issuerSigned = new IssuerSigned();
+        var issuerAuth = new byte[] { 0xD2, 0x84, 0x43, 0xA1 };
+
+        // Act
+        issuerSigned.IssuerAuth = issuerAuth;
+
+        // Assert
+        issuerSigned.IssuerAuth.Should().BeEquivalentTo(issuerAuth);
+    }
+
+    [Fact]
+    public void ToCbor_ReturnsValidCborBytes()
+    {
+        // Arrange
+        var issuerSigned = new IssuerSigned();
+        issuerSigned.NameSpaces["org.iso.18013.5.1"] = new List<IssuerSignedItem>
+        {
+            new()
+            {
+                DigestId = 0,
+                ElementIdentifier = "family_name",
+                ElementValue = "Doe",
+                Random = new byte[] { 0x01, 0x02, 0x03 }
+            }
+        };
+
+        // Act
+        var cborBytes = issuerSigned.ToCbor();
+
+        // Assert
+        cborBytes.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void FromCbor_WithValidData_RestoresIssuerSigned()
+    {
+        // Arrange
+        var original = new IssuerSigned();
+        original.NameSpaces["org.iso.18013.5.1"] = new List<IssuerSignedItem>
+        {
+            new()
+            {
+                DigestId = 0,
+                ElementIdentifier = "family_name",
+                ElementValue = "Doe",
+                Random = new byte[] { 0x01, 0x02, 0x03 }
+            }
+        };
+
+        var cborBytes = original.ToCbor();
+
+        // Act
+        var restored = IssuerSigned.FromCbor(cborBytes);
+
+        // Assert
+        restored.NameSpaces.Should().ContainKey("org.iso.18013.5.1");
+        restored.NameSpaces["org.iso.18013.5.1"].Should().HaveCount(1);
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Models/MobileSecurityObjectTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Models/MobileSecurityObjectTests.cs
@@ -1,0 +1,175 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Models;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Models;
+
+/// <summary>
+/// Tests for Mobile Security Object (MSO) per ISO 18013-5 Section 9.1.2.4.
+/// </summary>
+public class MobileSecurityObjectTests
+{
+    [Fact]
+    public void Constructor_CreatesDefaultValues()
+    {
+        // Act
+        var mso = new MobileSecurityObject();
+
+        // Assert
+        mso.Version.Should().Be("1.0");
+        mso.DigestAlgorithm.Should().Be("SHA-256");
+        mso.ValueDigests.Should().NotBeNull();
+        mso.ValueDigests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Version_SetValue_UpdatesCorrectly()
+    {
+        // Arrange
+        var mso = new MobileSecurityObject();
+
+        // Act
+        mso.Version = "1.0";
+
+        // Assert
+        mso.Version.Should().Be("1.0");
+    }
+
+    [Fact]
+    public void DigestAlgorithm_WithSHA256_IsValid()
+    {
+        // Arrange
+        var mso = new MobileSecurityObject { DigestAlgorithm = "SHA-256" };
+
+        // Assert
+        mso.DigestAlgorithm.Should().Be("SHA-256");
+    }
+
+    [Fact]
+    public void DigestAlgorithm_WithSHA384_IsValid()
+    {
+        // Arrange
+        var mso = new MobileSecurityObject { DigestAlgorithm = "SHA-384" };
+
+        // Assert
+        mso.DigestAlgorithm.Should().Be("SHA-384");
+    }
+
+    [Fact]
+    public void DigestAlgorithm_WithSHA512_IsValid()
+    {
+        // Arrange
+        var mso = new MobileSecurityObject { DigestAlgorithm = "SHA-512" };
+
+        // Assert
+        mso.DigestAlgorithm.Should().Be("SHA-512");
+    }
+
+    [Fact]
+    public void DocType_SetValue_UpdatesCorrectly()
+    {
+        // Arrange
+        var mso = new MobileSecurityObject();
+
+        // Act
+        mso.DocType = "org.iso.18013.5.1.mDL";
+
+        // Assert
+        mso.DocType.Should().Be("org.iso.18013.5.1.mDL");
+    }
+
+    [Fact]
+    public void ValueDigests_AddNamespace_StoresCorrectly()
+    {
+        // Arrange
+        var mso = new MobileSecurityObject();
+        var digests = new DigestIdMapping
+        {
+            Digests = new Dictionary<int, byte[]>
+            {
+                [0] = new byte[] { 0x01, 0x02, 0x03 },
+                [1] = new byte[] { 0x04, 0x05, 0x06 }
+            }
+        };
+
+        // Act
+        mso.ValueDigests["org.iso.18013.5.1"] = digests;
+
+        // Assert
+        mso.ValueDigests.Should().ContainKey("org.iso.18013.5.1");
+        mso.ValueDigests["org.iso.18013.5.1"].Digests.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void ValidityInfo_SetValues_StoredCorrectly()
+    {
+        // Arrange
+        var mso = new MobileSecurityObject();
+        var now = DateTimeOffset.UtcNow;
+
+        // Act
+        mso.ValidityInfo = new ValidityInfo
+        {
+            Signed = now,
+            ValidFrom = now,
+            ValidUntil = now.AddYears(5)
+        };
+
+        // Assert
+        mso.ValidityInfo.Signed.Should().Be(now);
+        mso.ValidityInfo.ValidFrom.Should().Be(now);
+        mso.ValidityInfo.ValidUntil.Should().Be(now.AddYears(5));
+    }
+
+    [Fact]
+    public void ToCbor_ReturnsValidCborBytes()
+    {
+        // Arrange
+        var mso = new MobileSecurityObject
+        {
+            Version = "1.0",
+            DigestAlgorithm = "SHA-256",
+            DocType = "org.iso.18013.5.1.mDL",
+            ValidityInfo = new ValidityInfo
+            {
+                Signed = DateTimeOffset.UtcNow,
+                ValidFrom = DateTimeOffset.UtcNow,
+                ValidUntil = DateTimeOffset.UtcNow.AddYears(5)
+            }
+        };
+
+        // Act
+        var cborBytes = mso.ToCbor();
+
+        // Assert
+        cborBytes.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void FromCbor_WithValidData_RestoresMso()
+    {
+        // Arrange
+        var original = new MobileSecurityObject
+        {
+            Version = "1.0",
+            DigestAlgorithm = "SHA-256",
+            DocType = "org.iso.18013.5.1.mDL",
+            ValidityInfo = new ValidityInfo
+            {
+                Signed = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero),
+                ValidFrom = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero),
+                ValidUntil = new DateTimeOffset(2029, 6, 15, 12, 0, 0, TimeSpan.Zero)
+            }
+        };
+
+        var cborBytes = original.ToCbor();
+
+        // Act
+        var restored = MobileSecurityObject.FromCbor(cborBytes);
+
+        // Assert
+        restored.Version.Should().Be(original.Version);
+        restored.DigestAlgorithm.Should().Be(original.DigestAlgorithm);
+        restored.DocType.Should().Be(original.DocType);
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Namespaces/MdlNamespaceTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Namespaces/MdlNamespaceTests.cs
@@ -1,0 +1,166 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Namespaces;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Namespaces;
+
+/// <summary>
+/// Tests for mDL namespace constants and data elements.
+/// </summary>
+public class MdlNamespaceTests
+{
+    [Fact]
+    public void Namespace_HasCorrectValue()
+    {
+        // Assert
+        MdlNamespace.Namespace.Should().Be("org.iso.18013.5.1");
+    }
+
+    [Fact]
+    public void DocType_HasCorrectValue()
+    {
+        // Assert
+        MdlNamespace.DocType.Should().Be("org.iso.18013.5.1.mDL");
+    }
+
+    [Theory]
+    [InlineData(MdlDataElement.FamilyName, "family_name")]
+    [InlineData(MdlDataElement.GivenName, "given_name")]
+    [InlineData(MdlDataElement.BirthDate, "birth_date")]
+    [InlineData(MdlDataElement.IssueDate, "issue_date")]
+    [InlineData(MdlDataElement.ExpiryDate, "expiry_date")]
+    [InlineData(MdlDataElement.IssuingCountry, "issuing_country")]
+    [InlineData(MdlDataElement.IssuingAuthority, "issuing_authority")]
+    [InlineData(MdlDataElement.DocumentNumber, "document_number")]
+    [InlineData(MdlDataElement.Portrait, "portrait")]
+    [InlineData(MdlDataElement.DrivingPrivileges, "driving_privileges")]
+    [InlineData(MdlDataElement.AgeOver18, "age_over_18")]
+    [InlineData(MdlDataElement.AgeOver21, "age_over_21")]
+    public void MdlDataElement_ToElementIdentifier_ReturnsCorrectString(MdlDataElement element, string expected)
+    {
+        // Act
+        var result = element.ToElementIdentifier();
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void AllMandatoryElements_ArePresent()
+    {
+        // ISO 18013-5 mandatory elements
+        var mandatoryElements = new[]
+        {
+            MdlDataElement.FamilyName,
+            MdlDataElement.GivenName,
+            MdlDataElement.BirthDate,
+            MdlDataElement.IssueDate,
+            MdlDataElement.ExpiryDate,
+            MdlDataElement.IssuingCountry,
+            MdlDataElement.IssuingAuthority,
+            MdlDataElement.DocumentNumber,
+            MdlDataElement.Portrait,
+            MdlDataElement.DrivingPrivileges,
+            MdlDataElement.UnDistinguishingSign
+        };
+
+        // Assert
+        foreach (var element in mandatoryElements)
+        {
+            Enum.IsDefined(typeof(MdlDataElement), element).Should().BeTrue();
+        }
+    }
+
+    [Fact]
+    public void MandatoryElements_ContainsAllRequired()
+    {
+        // Assert
+        MdlNamespace.MandatoryElements.Should().HaveCount(11);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.FamilyName);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.GivenName);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.BirthDate);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.IssueDate);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.ExpiryDate);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.IssuingCountry);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.IssuingAuthority);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.DocumentNumber);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.Portrait);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.DrivingPrivileges);
+        MdlNamespace.MandatoryElements.Should().Contain(MdlDataElement.UnDistinguishingSign);
+    }
+
+    [Fact]
+    public void IsMandatory_ForFamilyName_ReturnsTrue()
+    {
+        // Act
+        var result = MdlNamespace.IsMandatory(MdlDataElement.FamilyName);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsMandatory_ForAgeOver18_ReturnsFalse()
+    {
+        // Act
+        var result = MdlNamespace.IsMandatory(MdlDataElement.AgeOver18);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("family_name", MdlDataElement.FamilyName)]
+    [InlineData("given_name", MdlDataElement.GivenName)]
+    [InlineData("birth_date", MdlDataElement.BirthDate)]
+    [InlineData("age_over_18", MdlDataElement.AgeOver18)]
+    public void FromElementIdentifier_ReturnsCorrectElement(string identifier, MdlDataElement expected)
+    {
+        // Act
+        var result = MdlDataElementExtensions.FromElementIdentifier(identifier);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void FromElementIdentifier_WithInvalidIdentifier_ReturnsNull()
+    {
+        // Act
+        var result = MdlDataElementExtensions.FromElementIdentifier("invalid_element");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetFullIdentifier_ReturnsNamespaceWithElement()
+    {
+        // Act
+        var result = MdlNamespace.GetFullIdentifier(MdlDataElement.FamilyName);
+
+        // Assert
+        result.Should().Be("org.iso.18013.5.1.family_name");
+    }
+
+    [Fact]
+    public void CreateClaims_CreatesDictionaryWithCorrectStructure()
+    {
+        // Arrange
+        var claims = new Dictionary<MdlDataElement, object>
+        {
+            { MdlDataElement.FamilyName, "Doe" },
+            { MdlDataElement.GivenName, "John" }
+        };
+
+        // Act
+        var result = MdlNamespace.CreateClaims(claims);
+
+        // Assert
+        result.Should().ContainKey(MdlNamespace.Namespace);
+        result[MdlNamespace.Namespace].Should().ContainKey("family_name");
+        result[MdlNamespace.Namespace].Should().ContainKey("given_name");
+        result[MdlNamespace.Namespace]["family_name"].Should().Be("Doe");
+        result[MdlNamespace.Namespace]["given_name"].Should().Be("John");
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/SdJwt.Net.Mdoc.Tests.csproj
+++ b/tests/SdJwt.Net.Mdoc.Tests/SdJwt.Net.Mdoc.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>12.0</LangVersion>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="FluentAssertions" Version="6.12.2" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\SdJwt.Net.Mdoc\SdJwt.Net.Mdoc.csproj" />
+    </ItemGroup>
+</Project>

--- a/tests/SdJwt.Net.Mdoc.Tests/TestBase.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/TestBase.cs
@@ -1,0 +1,78 @@
+using System.Security.Cryptography;
+
+namespace SdJwt.Net.Mdoc.Tests;
+
+/// <summary>
+/// Base class for mdoc tests with shared test infrastructure.
+/// </summary>
+public abstract class TestBase : IDisposable
+{
+    /// <summary>
+    /// EC P-256 issuer signing key for tests.
+    /// </summary>
+    protected ECDsa IssuerSigningKey { get; }
+
+    /// <summary>
+    /// EC P-256 device key for holder binding tests.
+    /// </summary>
+    protected ECDsa DeviceKey { get; }
+
+    /// <summary>
+    /// EC P-384 issuer signing key for ES384 tests.
+    /// </summary>
+    protected ECDsa IssuerSigningKeyEs384 { get; }
+
+    /// <summary>
+    /// Fixed test document type for mDL.
+    /// </summary>
+    protected const string MdlDocType = "org.iso.18013.5.1.mDL";
+
+    /// <summary>
+    /// Fixed test namespace for mDL.
+    /// </summary>
+    protected const string MdlNamespace = "org.iso.18013.5.1";
+
+    protected TestBase()
+    {
+        IssuerSigningKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DeviceKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        IssuerSigningKeyEs384 = ECDsa.Create(ECCurve.NamedCurves.nistP384);
+    }
+
+    /// <summary>
+    /// Creates test mDL data elements.
+    /// </summary>
+    protected static Dictionary<string, object> CreateTestMdlElements()
+    {
+        return new Dictionary<string, object>
+        {
+            ["family_name"] = "Doe",
+            ["given_name"] = "John",
+            ["birth_date"] = "1990-01-15",
+            ["issue_date"] = "2024-01-01",
+            ["expiry_date"] = "2029-01-01",
+            ["issuing_country"] = "US",
+            ["issuing_authority"] = "State DMV",
+            ["document_number"] = "DL123456789",
+            ["driving_privileges"] = new[]
+            {
+                new Dictionary<string, object>
+                {
+                    ["vehicle_category_code"] = "B",
+                    ["issue_date"] = "2024-01-01",
+                    ["expiry_date"] = "2029-01-01"
+                }
+            },
+            ["age_over_18"] = true,
+            ["age_over_21"] = true
+        };
+    }
+
+    public void Dispose()
+    {
+        IssuerSigningKey.Dispose();
+        DeviceKey.Dispose();
+        IssuerSigningKeyEs384.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/SdJwt.Net.Mdoc.Tests/Verifier/MdocVerifierTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Verifier/MdocVerifierTests.cs
@@ -1,0 +1,204 @@
+using FluentAssertions;
+using SdJwt.Net.Mdoc.Cose;
+using SdJwt.Net.Mdoc.Handover;
+using SdJwt.Net.Mdoc.Issuer;
+using SdJwt.Net.Mdoc.Models;
+using SdJwt.Net.Mdoc.Namespaces;
+using SdJwt.Net.Mdoc.Verifier;
+using Xunit;
+
+namespace SdJwt.Net.Mdoc.Tests.Verifier;
+
+/// <summary>
+/// Tests for MdocVerifier credential verification.
+/// </summary>
+public class MdocVerifierTests : TestBase
+{
+    [Fact]
+    public void Constructor_WithDefaultOptions_CreatesVerifier()
+    {
+        // Act
+        var verifier = new MdocVerifier();
+
+        // Assert
+        verifier.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Constructor_WithCustomOptions_CreatesVerifier()
+    {
+        // Arrange
+        var options = new MdocVerificationOptions
+        {
+            VerifyValidity = true,
+            VerifyDeviceSignature = false
+        };
+
+        // Act
+        var verifier = new MdocVerifier(options);
+
+        // Assert
+        verifier.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Constructor_WithCryptoProvider_CreatesVerifier()
+    {
+        // Arrange
+        var options = new MdocVerificationOptions();
+        var cryptoProvider = new DefaultCoseCryptoProvider();
+
+        // Act
+        var verifier = new MdocVerifier(options, cryptoProvider);
+
+        // Assert
+        verifier.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Verify_WithEmptyDeviceResponse_ReturnsEmptyResults()
+    {
+        // Arrange
+        var verifier = new MdocVerifier();
+        var response = new DeviceResponse();
+
+        // Act
+        var results = verifier.Verify(response);
+
+        // Assert
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void VerifyDocument_WithDisallowedDocType_ReturnsInvalid()
+    {
+        // Arrange
+        var options = new MdocVerificationOptions
+        {
+            AllowedDocTypes = new List<string> { "org.example.other" }
+        };
+        var verifier = new MdocVerifier(options);
+        var document = new Document
+        {
+            DocType = MdlDocType,
+            IssuerSigned = new IssuerSigned()
+        };
+
+        // Act
+        var result = verifier.VerifyDocument(document);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("not allowed"));
+    }
+
+    [Fact]
+    public void VerifyDocument_WithAllowedDocType_ContinuesVerification()
+    {
+        // Arrange
+        var options = new MdocVerificationOptions
+        {
+            AllowedDocTypes = new List<string> { MdlDocType }
+        };
+        var verifier = new MdocVerifier(options);
+        var document = new Document
+        {
+            DocType = MdlDocType,
+            IssuerSigned = new IssuerSigned()
+        };
+
+        // Act - will fail due to empty IssuerAuth, but not due to doc type
+        var result = verifier.VerifyDocument(document);
+
+        // Assert - should fail for other reasons, not doc type
+        result.Errors.Should().NotContain(e => e.Contains("not allowed"));
+    }
+
+    [Fact]
+    public void MdocVerificationOptions_DefaultValues_AreCorrect()
+    {
+        // Act
+        var options = new MdocVerificationOptions();
+
+        // Assert
+        options.AllowedDocTypes.Should().BeEmpty();
+        options.VerifyCertificateChain.Should().BeTrue();
+        options.VerifyValidity.Should().BeTrue();
+        options.VerifyDeviceSignature.Should().BeTrue();
+        options.ClockSkewTolerance.Should().Be(TimeSpan.FromMinutes(5));
+        options.CurrentTime.Should().BeNull();
+        options.TrustedIssuers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MdocVerificationResult_Success_CreatesValidResult()
+    {
+        // Act
+        var result = MdocVerificationResult.Success();
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.IssuerSignatureValid.Should().BeTrue();
+        result.DigestsValid.Should().BeTrue();
+        result.ValidityPeriodValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MdocVerificationResult_Failure_CreatesInvalidResult()
+    {
+        // Act
+        var result = MdocVerificationResult.Failure("Test error");
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain("Test error");
+    }
+
+    [Fact]
+    public void Verify_WithDeviceResponse_ReturnsResultPerDocument()
+    {
+        // Arrange
+        var verifier = new MdocVerifier();
+        var response = new DeviceResponse();
+        response.Documents.Add(new Document
+        {
+            DocType = MdlDocType,
+            IssuerSigned = new IssuerSigned()
+        });
+        response.Documents.Add(new Document
+        {
+            DocType = "org.example.other",
+            IssuerSigned = new IssuerSigned()
+        });
+
+        // Act
+        var results = verifier.Verify(response);
+
+        // Assert
+        results.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void VerifyDocument_WithSessionTranscript_AcceptsTranscript()
+    {
+        // Arrange
+        var verifier = new MdocVerifier();
+        var document = new Document
+        {
+            DocType = MdlDocType,
+            IssuerSigned = new IssuerSigned()
+        };
+        var transcript = SessionTranscript.ForOpenId4Vp(
+            "client123",
+            "nonce456",
+            null,
+            "https://verifier.example.com/callback");
+
+        // Act
+        var result = verifier.VerifyDocument(document, transcript);
+
+        // Assert
+        result.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Introduce a new SdJwt.Net.Mdoc package to add ISO 18013-5 mdoc/mDL support. Implements CBOR/COSE primitives, MSO, issuer builder, verifier, session transcript/handover (OpenID4VP & DC API), namespaces, and a pluggable ICoseCryptoProvider, with comprehensive unit and integration tests. Documentation and tutorials added (deep dive, beginner/intermediate/advanced tutorials, use-case), README/AGENTS/ENTERPRISE_ROADMAP updated to include the new package and CI expectations (8 -> 9 packages / test suites), and roadmap status adjusted to reflect completion of Phase 2. Tests and sample code/examples for issuance, presentation, and verification are included.