### PR TITLE
Add MCP Trust demo and refine CI release workflow

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -6,11 +6,11 @@ name: "Publish to NuGet (Production)"
 
 on:
   release:
-    types: [published]
+    types: [ published ]
   workflow_dispatch:
     inputs:
       dry-run:
-        description: 'Perform a dry run (build and pack but do not publish)'
+        description: "Perform a dry run (build and pack but do not publish)"
         required: false
         default: false
         type: boolean
@@ -24,8 +24,8 @@ jobs:
   build-and-test:
     uses: ./.github/workflows/reusable-build-pack.yml
     with:
-      dotnet-version: '9.0.x'
-      configuration: 'Release'
+      dotnet-version: "9.0.x"
+      configuration: "Release"
       enable-code-coverage: true
 
   # Job 2: Validate complete ecosystem and publish to NuGet
@@ -38,315 +38,319 @@ jobs:
       contents: read
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '9.0.x'
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
-    - name: Download NuGet packages
-      uses: actions/download-artifact@v4
-      with:
-        name: nuget-packages
-        path: ./packages
+      - name: Download NuGet packages
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./packages
 
-    - name: Validate complete SD-JWT .NET ecosystem
-      run: |
-        echo "Validating complete SD-JWT .NET ecosystem packages..."
+      - name: Validate complete SD-JWT .NET ecosystem
+        run: |
+          echo "Validating complete SD-JWT .NET ecosystem packages..."
 
-        declare -A ecosystem_packages=(
-          ["SdJwt.Net"]="Core SD-JWT functionality with RFC 9901 compliance"
-          ["SdJwt.Net.Vc"]="Verifiable Credentials with draft-ietf-oauth-sd-jwt-vc-13"
-          ["SdJwt.Net.StatusList"]="Credential lifecycle management with draft-ietf-oauth-status-list-13"
-          ["SdJwt.Net.Oid4Vci"]="Credential issuance with OpenID4VCI 1.0"
-          ["SdJwt.Net.Oid4Vp"]="Presentation protocols with OpenID4VP 1.0"
-          ["SdJwt.Net.OidFederation"]="Trust infrastructure with OpenID Federation 1.0"
-          ["SdJwt.Net.PresentationExchange"]="Intelligent credential selection with DIF PE v2.1.1"
-          ["SdJwt.Net.HAIP"]="High assurance compliance with HAIP 1.0"
-        )
+          declare -A ecosystem_packages=(
+            ["SdJwt.Net"]="Core SD-JWT functionality with RFC 9901 compliance"
+            ["SdJwt.Net.Vc"]="Verifiable Credentials with draft-ietf-oauth-sd-jwt-vc-13"
+            ["SdJwt.Net.StatusList"]="Credential lifecycle management with draft-ietf-oauth-status-list-13"
+            ["SdJwt.Net.Oid4Vci"]="Credential issuance with OpenID4VCI 1.0"
+            ["SdJwt.Net.Oid4Vp"]="Presentation protocols with OpenID4VP 1.0"
+            ["SdJwt.Net.OidFederation"]="Trust infrastructure with OpenID Federation 1.0"
+            ["SdJwt.Net.PresentationExchange"]="Intelligent credential selection with DIF PE v2.1.1"
+            ["SdJwt.Net.HAIP"]="High assurance compliance with HAIP 1.0"
+          )
 
-        echo "Expected ecosystem packages:"
-        for package in "${!ecosystem_packages[@]}"; do
-          echo "  $package: ${ecosystem_packages[$package]}"
-        done
-        echo ""
-
-        found_packages=()
-        missing_packages=()
-
-        for package in "${!ecosystem_packages[@]}"; do
-          if ls ./packages/${package}.*.nupkg 1> /dev/null 2>&1; then
-            package_file=$(ls ./packages/${package}.*.nupkg | grep -v symbols | head -1)
-            size=$(du -h "$package_file" | cut -f1)
-            echo "Found: $package ($size)"
-            found_packages+=("$package")
-          else
-            echo "ERROR: Missing: $package"
-            missing_packages+=("$package")
-          fi
-        done
-
-        echo ""
-        echo "Ecosystem Validation Summary:"
-        echo "  Found: ${#found_packages[@]}/${#ecosystem_packages[@]} packages"
-        echo "  Missing: ${#missing_packages[@]} packages"
-
-        if [ ${#missing_packages[@]} -gt 0 ]; then
-          echo ""
-          echo "ERROR: Incomplete ecosystem detected!"
-          echo "Missing packages: ${missing_packages[*]}"
-          echo "Cannot proceed with ecosystem release."
-          exit 1
-        fi
-
-        echo ""
-        echo "Complete SD-JWT .NET ecosystem validated!"
-
-    - name: Enhanced package integrity validation
-      if: github.event_name == 'release'
-      run: |
-        echo "Enhanced package integrity validation..."
-        SEMVER_PATTERN='\.[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?'
-
-        for package in ./packages/*.nupkg; do
-          if [[ ! "$package" =~ \.symbols\. ]] && [[ -f "$package" ]]; then
-            package_name=$(basename "$package")
-            echo ""
-            echo "Validating: $package_name"
-
-            size=$(stat -c%s "$package" 2>/dev/null || echo "0")
-            size_kb=$((size / 1024))
-
-            if [ "$size" -lt 10000 ]; then
-              echo "  WARNING: Small package size: ${size_kb}KB"
-            else
-              echo "  Package size OK: ${size_kb}KB"
-            fi
-
-            if [[ "$package_name" =~ $SEMVER_PATTERN ]]; then
-              echo "  Valid semver version confirmed"
-            else
-              echo "  WARNING: Unexpected version pattern"
-            fi
-          fi
-        done
-
-        echo ""
-        echo "Enhanced package validation completed"
-
-    - name: List ecosystem packages to be published
-      run: |
-        echo "SD-JWT .NET Ecosystem packages ready for publication:"
-        echo ""
-
-        main_packages=()
-        symbol_packages=()
-
-        for package in ./packages/*.nupkg; do
-          package_name=$(basename "$package")
-          if [[ "$package" =~ \.symbols\. ]]; then
-            symbol_packages+=("$package_name")
-          else
-            main_packages+=("$package_name")
-          fi
-        done
-
-        echo "Main packages (${#main_packages[@]}):"
-        for package in "${main_packages[@]}"; do
-          echo "  $package"
-        done
-
-        echo ""
-        echo "Symbol packages (${#symbol_packages[@]}):"
-        for package in "${symbol_packages[@]}"; do
-          echo "  $package"
-        done
-
-    - name: Dry run - Show ecosystem publication plan
-      if: github.event_name == 'workflow_dispatch' && inputs.dry-run == true
-      run: |
-        echo "DRY RUN MODE - SD-JWT .NET Ecosystem Publication Plan"
-        echo ""
-        echo "The following packages would be published to NuGet.org:"
-        echo ""
-
-        total_size=0
-        package_count=0
-
-        for package in ./packages/*.nupkg; do
-          if [[ ! "$package" =~ \.symbols\. ]]; then
-            package_name=$(basename "$package")
-            size=$(stat -c%s "$package" 2>/dev/null || echo "0")
-            size_kb=$((size / 1024))
-            total_size=$((total_size + size))
-            package_count=$((package_count + 1))
-
-            echo "  $package_name (${size_kb}KB)"
-          fi
-        done
-
-        total_size_mb=$((total_size / 1024 / 1024))
-        echo ""
-        echo "Publication Summary:"
-        echo "  Total packages: $package_count"
-        echo "  Total size: ${total_size_mb}MB"
-        echo ""
-        echo "DRY RUN - No actual publishing performed"
-
-    - name: Authenticate to NuGet.org (Trusted Publishing via OIDC)
-      id: nuget-login
-      if: github.event_name != 'workflow_dispatch' || inputs.dry-run != true
-      uses: NuGet/login@v1
-      with:
-        user: ${{ vars.NUGET_USERNAME }}
-
-    - name: Publish main ecosystem packages to NuGet (Trusted Publishing via OIDC)
-      if: github.event_name != 'workflow_dispatch' || inputs.dry-run != true
-      env:
-        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
-      run: |
-        echo "Publishing SD-JWT .NET Ecosystem to NuGet.org via Trusted Publishing..."
-        echo ""
-
-        success_count=0
-        total_count=0
-        failed_packages=()
-
-        for package in ./packages/*.nupkg; do
-          if [[ ! "$package" =~ \.symbols\. ]]; then
-            total_count=$((total_count + 1))
-            package_name=$(basename "$package")
-
-            echo "Publishing: $package_name"
-            echo "   Target: NuGet.org"
-            echo "   Status: In progress..."
-
-            push_cmd=(dotnet nuget push "$package" --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate --timeout 300)
-
-            if "${push_cmd[@]}"; then
-              echo "   Result: SUCCESS"
-              success_count=$((success_count + 1))
-            else
-              echo "   Result: FAILED"
-              failed_packages+=("$package_name")
-            fi
-            echo "   ---"
-          fi
-        done
-
-        echo ""
-        echo "Main Packages Publication Summary:"
-        echo "  Successful: $success_count/$total_count"
-        echo "  Failed: ${#failed_packages[@]}"
-
-        if [ ${#failed_packages[@]} -gt 0 ]; then
-          echo ""
-          echo "Failed packages:"
-          for package in "${failed_packages[@]}"; do
-            echo "  $package"
+          echo "Expected ecosystem packages:"
+          for package in "${!ecosystem_packages[@]}"; do
+            echo "  $package: ${ecosystem_packages[$package]}"
           done
           echo ""
-          echo "ERROR: Some ecosystem packages failed to publish!"
-          exit 1
-        fi
 
-        echo ""
-        echo "All main ecosystem packages published successfully!"
+          found_packages=()
+          missing_packages=()
 
-    - name: Publish symbol packages to NuGet
-      if: (github.event_name != 'workflow_dispatch' || inputs.dry-run != true) && success()
-      env:
-        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
-      run: |
-        echo "Publishing symbol packages to NuGet.org..."
-        echo ""
+          for package in "${!ecosystem_packages[@]}"; do
+            if ls ./packages/${package}.*.nupkg 1> /dev/null 2>&1; then
+              package_file=$(ls ./packages/${package}.*.nupkg | grep -v symbols | head -1)
+              size=$(du -h "$package_file" | cut -f1)
+              echo "Found: $package ($size)"
+              found_packages+=("$package")
+            else
+              echo "ERROR: Missing: $package"
+              missing_packages+=("$package")
+            fi
+          done
 
-        symbol_count=0
-        symbol_success=0
+          echo ""
+          echo "Ecosystem Validation Summary:"
+          echo "  Found: ${#found_packages[@]}/${#ecosystem_packages[@]} packages"
+          echo "  Missing: ${#missing_packages[@]} packages"
 
-        for package in ./packages/*symbols*.nupkg; do
-          if [[ -f "$package" ]]; then
-            symbol_count=$((symbol_count + 1))
+          if [ ${#missing_packages[@]} -gt 0 ]; then
+            echo ""
+            echo "ERROR: Incomplete ecosystem detected!"
+            echo "Missing packages: ${missing_packages[*]}"
+            echo "Cannot proceed with ecosystem release."
+            exit 1
+          fi
+
+          echo ""
+          echo "Complete SD-JWT .NET ecosystem validated!"
+
+      - name: Enhanced package integrity validation
+        if: github.event_name == 'release'
+        run: |
+          echo "Enhanced package integrity validation..."
+          SEMVER_PATTERN='\.[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?'
+
+          for package in ./packages/*.nupkg; do
+            if [[ ! "$package" =~ \.symbols\. ]] && [[ -f "$package" ]]; then
+              package_name=$(basename "$package")
+              echo ""
+              echo "Validating: $package_name"
+
+              size=$(stat -c%s "$package" 2>/dev/null || echo "0")
+              size_kb=$((size / 1024))
+
+              if [ "$size" -lt 10000 ]; then
+                echo "  WARNING: Small package size: ${size_kb}KB"
+              else
+                echo "  Package size OK: ${size_kb}KB"
+              fi
+
+              if [[ "$package_name" =~ $SEMVER_PATTERN ]]; then
+                echo "  Valid semver version confirmed"
+              else
+                echo "  WARNING: Unexpected version pattern"
+              fi
+            fi
+          done
+
+          echo ""
+          echo "Enhanced package validation completed"
+
+      - name: List ecosystem packages to be published
+        run: |
+          echo "SD-JWT .NET Ecosystem packages ready for publication:"
+          echo ""
+
+          main_packages=()
+          symbol_packages=()
+
+          for package in ./packages/*.nupkg; do
             package_name=$(basename "$package")
-            echo "Publishing symbol package: $package_name"
-
-            push_cmd=(dotnet nuget push "$package" --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate --timeout 300)
-
-            if "${push_cmd[@]}"; then
-              echo "   Successfully published symbol package"
-              symbol_success=$((symbol_success + 1))
+            if [[ "$package" =~ \.symbols\. ]]; then
+              symbol_packages+=("$package_name")
             else
-              echo "   WARNING: Failed to publish symbol package (continuing...)"
+              main_packages+=("$package_name")
             fi
-          fi
-        done
+          done
 
-        echo ""
-        if [[ $symbol_count -eq 0 ]]; then
-          echo "No symbol packages found"
-        else
-          echo "Symbol packages: $symbol_success/$symbol_count published"
-        fi
+          echo "Main packages (${#main_packages[@]}):"
+          for package in "${main_packages[@]}"; do
+            echo "  $package"
+          done
 
-    - name: Create release summary
-      if: success()
-      run: |
-        release_version="${GITHUB_REF#refs/tags/}"
+          echo ""
+          echo "Symbol packages (${#symbol_packages[@]}):"
+          for package in "${symbol_packages[@]}"; do
+            echo "  $package"
+          done
 
-        echo "# SD-JWT .NET Ecosystem $release_version Released Successfully" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "The complete SD-JWT .NET ecosystem has been published to NuGet.org!" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+      - name: Dry run - Show ecosystem publication plan
+        if: github.event_name == 'workflow_dispatch' && inputs.dry-run == true
+        run: |
+          echo "DRY RUN MODE - SD-JWT .NET Ecosystem Publication Plan"
+          echo ""
+          echo "The following packages would be published to NuGet.org:"
+          echo ""
 
-        echo "## Published Ecosystem Packages" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+          total_size=0
+          package_count=0
 
-        declare -A package_descriptions=(
-          ["SdJwt.Net"]="Core SD-JWT functionality with RFC 9901 compliance"
-          ["SdJwt.Net.Vc"]="Verifiable Credentials with draft-13 support"
-          ["SdJwt.Net.StatusList"]="Credential lifecycle management"
-          ["SdJwt.Net.Oid4Vci"]="Credential issuance with OpenID4VCI 1.0"
-          ["SdJwt.Net.Oid4Vp"]="Presentation protocols with OpenID4VP 1.0"
-          ["SdJwt.Net.OidFederation"]="Trust infrastructure with OpenID Federation 1.0"
-          ["SdJwt.Net.PresentationExchange"]="Intelligent credential selection with DIF PE v2.1.1"
-          ["SdJwt.Net.HAIP"]="High assurance compliance with HAIP 1.0"
-        )
+          for package in ./packages/*.nupkg; do
+            if [[ ! "$package" =~ \.symbols\. ]]; then
+              package_name=$(basename "$package")
+              size=$(stat -c%s "$package" 2>/dev/null || echo "0")
+              size_kb=$((size / 1024))
+              total_size=$((total_size + size))
+              package_count=$((package_count + 1))
 
-        for package in ./packages/*.nupkg; do
-          if [[ ! "$package" =~ \.symbols\. ]]; then
-            package_name=$(basename "$package" .nupkg | sed 's/\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*//')
-            if [[ -n "${package_descriptions[$package_name]}" ]]; then
-              echo "- **\`$package_name\`** - ${package_descriptions[$package_name]}" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "- **\`$package_name\`**" >> $GITHUB_STEP_SUMMARY
+              echo "  $package_name (${size_kb}KB)"
             fi
-          fi
-        done
+          done
 
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## Quick Links" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "- [NuGet.org packages](https://www.nuget.org/packages?q=sdjwt.net+openwalletfoundation)" >> $GITHUB_STEP_SUMMARY
-        echo "- [Documentation](https://github.com/openwallet-foundation-labs/sd-jwt-dotnet/tree/main/docs)" >> $GITHUB_STEP_SUMMARY
-        echo "- [Getting Started](https://github.com/openwallet-foundation-labs/sd-jwt-dotnet/blob/main/docs/getting-started/quickstart.md)" >> $GITHUB_STEP_SUMMARY
-        echo "- [Release notes](${{ github.event.release.html_url }})" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## Installation" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-        echo "dotnet add package SdJwt.Net" >> $GITHUB_STEP_SUMMARY
-        echo "dotnet add package SdJwt.Net.Vc" >> $GITHUB_STEP_SUMMARY
-        echo "dotnet add package SdJwt.Net.StatusList" >> $GITHUB_STEP_SUMMARY
-        echo "dotnet add package SdJwt.Net.Oid4Vci" >> $GITHUB_STEP_SUMMARY
-        echo "dotnet add package SdJwt.Net.Oid4Vp" >> $GITHUB_STEP_SUMMARY
-        echo "dotnet add package SdJwt.Net.OidFederation" >> $GITHUB_STEP_SUMMARY
-        echo "dotnet add package SdJwt.Net.PresentationExchange" >> $GITHUB_STEP_SUMMARY
-        echo "dotnet add package SdJwt.Net.HAIP" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          total_size_mb=$((total_size / 1024 / 1024))
+          echo ""
+          echo "Publication Summary:"
+          echo "  Total packages: $package_count"
+          echo "  Total size: ${total_size_mb}MB"
+          echo ""
+          echo "DRY RUN - No actual publishing performed"
+
+      - name: Authenticate to NuGet.org (Trusted Publishing via OIDC)
+        id: nuget-login
+        if: github.event_name != 'workflow_dispatch' || inputs.dry-run != true
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USERNAME }}
+
+      - name: Publish main ecosystem packages to NuGet (Trusted Publishing via OIDC)
+        if: github.event_name != 'workflow_dispatch' || inputs.dry-run != true
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        run: |
+          echo "Publishing SD-JWT .NET Ecosystem to NuGet.org via Trusted Publishing..."
+          echo ""
+
+          success_count=0
+          total_count=0
+          failed_packages=()
+
+          for package in ./packages/*.nupkg; do
+            if [[ ! "$package" =~ \.symbols\. ]]; then
+              total_count=$((total_count + 1))
+              package_name=$(basename "$package")
+
+              echo "Publishing: $package_name"
+              echo "   Target: NuGet.org"
+              echo "   Status: In progress..."
+
+              push_cmd=(dotnet nuget push "$package" --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate --timeout 300)
+
+              if "${push_cmd[@]}"; then
+                echo "   Result: SUCCESS"
+                success_count=$((success_count + 1))
+              else
+                echo "   Result: FAILED"
+                failed_packages+=("$package_name")
+              fi
+              echo "   ---"
+            fi
+          done
+
+          echo ""
+          echo "Main Packages Publication Summary:"
+          echo "  Successful: $success_count/$total_count"
+          echo "  Failed: ${#failed_packages[@]}"
+
+          if [ ${#failed_packages[@]} -gt 0 ]; then
+            echo ""
+            echo "Failed packages:"
+            for package in "${failed_packages[@]}"; do
+              echo "  $package"
+            done
+            echo ""
+            echo "ERROR: Some ecosystem packages failed to publish!"
+            exit 1
+          fi
+
+          echo ""
+          echo "All main ecosystem packages published successfully!"
+
+      - name: Publish symbol packages to NuGet
+        if: (github.event_name != 'workflow_dispatch' || inputs.dry-run != true) &&
+          success()
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        run: |
+          echo "Publishing symbol packages to NuGet.org..."
+          echo ""
+
+          symbol_count=0
+          symbol_success=0
+
+          for package in ./packages/*symbols*.nupkg; do
+            if [[ -f "$package" ]]; then
+              symbol_count=$((symbol_count + 1))
+              package_name=$(basename "$package")
+              echo "Publishing symbol package: $package_name"
+
+              push_cmd=(dotnet nuget push "$package" --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate --timeout 300)
+
+              if "${push_cmd[@]}"; then
+                echo "   Successfully published symbol package"
+                symbol_success=$((symbol_success + 1))
+              else
+                echo "   WARNING: Failed to publish symbol package (continuing...)"
+              fi
+            fi
+          done
+
+          echo ""
+          if [[ $symbol_count -eq 0 ]]; then
+            echo "No symbol packages found"
+          else
+            echo "Symbol packages: $symbol_success/$symbol_count published"
+          fi
+
+      - name: Create release summary
+        if: success()
+        run: |
+          release_version="${GITHUB_REF#refs/tags/}"
+
+          echo "# SD-JWT .NET Ecosystem $release_version Released Successfully" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The complete SD-JWT .NET ecosystem has been published to NuGet.org!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "## Published Ecosystem Packages" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          declare -A package_descriptions=(
+            ["SdJwt.Net"]="Core SD-JWT functionality with RFC 9901 compliance"
+            ["SdJwt.Net.Vc"]="Verifiable Credentials with draft-13 support"
+            ["SdJwt.Net.StatusList"]="Credential lifecycle management"
+            ["SdJwt.Net.Oid4Vci"]="Credential issuance with OpenID4VCI 1.0"
+            ["SdJwt.Net.Oid4Vp"]="Presentation protocols with OpenID4VP 1.0"
+            ["SdJwt.Net.OidFederation"]="Trust infrastructure with OpenID Federation 1.0"
+            ["SdJwt.Net.PresentationExchange"]="Intelligent credential selection with DIF PE v2.1.1"
+            ["SdJwt.Net.HAIP"]="High assurance compliance with HAIP 1.0"
+          )
+
+          for package in ./packages/*.nupkg; do
+            if [[ ! "$package" =~ \.symbols\. ]]; then
+              package_name=$(basename "$package" .nupkg | sed 's/\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*//')
+              if [[ -n "${package_descriptions[$package_name]}" ]]; then
+                echo "- **\`$package_name\`** - ${package_descriptions[$package_name]}" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "- **\`$package_name\`**" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Quick Links" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- [NuGet.org packages](https://www.nuget.org/packages?q=sdjwt.net+openwalletfoundation)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Documentation](https://github.com/openwallet-foundation-labs/sd-jwt-dotnet/tree/main/docs)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Getting Started](https://github.com/openwallet-foundation-labs/sd-jwt-dotnet/blob/main/docs/getting-started/quickstart.md)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Release notes](${{ github.event.release.html_url }})" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Installation" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "dotnet add package SdJwt.Net" >> $GITHUB_STEP_SUMMARY
+          echo "dotnet add package SdJwt.Net.Vc" >> $GITHUB_STEP_SUMMARY
+          echo "dotnet add package SdJwt.Net.StatusList" >> $GITHUB_STEP_SUMMARY
+          echo "dotnet add package SdJwt.Net.Oid4Vci" >> $GITHUB_STEP_SUMMARY
+          echo "dotnet add package SdJwt.Net.Oid4Vp" >> $GITHUB_STEP_SUMMARY
+          echo "dotnet add package SdJwt.Net.OidFederation" >> $GITHUB_STEP_SUMMARY
+          echo "dotnet add package SdJwt.Net.PresentationExchange" >> $GITHUB_STEP_SUMMARY
+          echo "dotnet add package SdJwt.Net.HAIP" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   ecosystem-announcement:
     needs: publish-ecosystem
@@ -354,13 +358,13 @@ jobs:
     if: success() && github.event_name == 'release'
 
     steps:
-    - name: Create ecosystem announcement
-      run: |
-        echo "SD-JWT .NET Ecosystem Release Complete!"
-        echo ""
-        echo "Version: ${GITHUB_REF#refs/tags/}"
-        echo "Packages: 8 core ecosystem packages"
-        echo "Standards: RFC 9901, OpenID4VCI/VP 1.0, DIF PE v2.1.1, HAIP 1.0"
-        echo "Platforms: .NET 8, .NET 9, .NET Standard 2.1"
-        echo ""
-        echo "The complete SD-JWT .NET ecosystem is now available on NuGet.org!"
+      - name: Create ecosystem announcement
+        run: |
+          echo "SD-JWT .NET Ecosystem Release Complete!"
+          echo ""
+          echo "Version: ${GITHUB_REF#refs/tags/}"
+          echo "Packages: 8 core ecosystem packages"
+          echo "Standards: RFC 9901, OpenID4VCI/VP 1.0, DIF PE v2.1.1, HAIP 1.0"
+          echo "Platforms: .NET 8, .NET 9, .NET Standard 2.1"
+          echo ""
+          echo "The complete SD-JWT .NET ecosystem is now available on NuGet.org!"

--- a/.github/workflows/reusable-build-pack.yml
+++ b/.github/workflows/reusable-build-pack.yml
@@ -56,10 +56,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET ${{ inputs.dotnet-version }}
+      - name: Setup .NET SDKs
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ inputs.dotnet-version }}
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -73,7 +76,8 @@ jobs:
         run: dotnet restore SdJwt.Net.sln
 
       - name: Build solution
-        run: dotnet build SdJwt.Net.sln --configuration ${{ inputs.configuration }} --no-restore
+        run: dotnet build SdJwt.Net.sln --configuration ${{ inputs.configuration }}
+          --no-restore
 
       - name: Test Core SD-JWT Libraries
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "git commit": true,
         "dotnet format": true,
         "dotnet sln": true,
-        "dotnet pack": true
+        "dotnet pack": true,
+        "dotnet run": true
     }
 }

--- a/docs/concepts/agent-trust-kits-deep-dive.md
+++ b/docs/concepts/agent-trust-kits-deep-dive.md
@@ -50,6 +50,29 @@ Agent Trust Kit extends the SD-JWT .NET ecosystem from **human-held verifiable c
 
 ---
 
+## Terminology - Why "Minting" and Not "Issuing"
+
+Throughout this project, the act of creating a capability token is called **minting** rather than the more familiar OAuth term "issuing." This is a deliberate choice rooted in **capability-based security** literature:
+
+| Term      | Origin                                      | Connotation                                                     |
+| --------- | ------------------------------------------- | --------------------------------------------------------------- |
+| **Mint**  | Object-capability model, Macaroons, ZCAP-LD | Create a fresh, scoped, ephemeral capability on demand          |
+| **Issue** | OAuth 2.0, OpenID4VCI, X.509                | Grant a longer-lived credential from a trusted authority        |
+| **Grant** | OAuth 2.0 Authorization Framework           | Authorize a client through a specific flow (code, device, etc.) |
+
+Key differences that make "minting" the right fit for Agent Trust:
+
+- **Ephemeral scope.** A capability token lives for seconds to minutes and authorizes exactly one action. OAuth tokens are typically session-length or longer.
+- **Inline creation.** The caller creates the token itself (after policy approval) rather than requesting it from a remote authorization server.
+- **No audience negotiation.** The mint operation is unilateral - no round-trip to the resource owner or an authorization endpoint.
+- **Capability semantics.** In the object-capability model, "minting a capability" means constructing a transferable proof of authority. The token is the authority - possessing it is sufficient to act.
+
+The `CapabilityTokenIssuer` class name uses "Issuer" for consistency with the SD-JWT ecosystem (where `SdIssuer` is the core primitive), but its primary method is `Mint()` to signal the capability-security intent.
+
+**If you come from the OAuth/OIDC world:** Read "mint" as "issue a short-lived, single-use capability token inline without a token endpoint."
+
+---
+
 ## How It Works - Step by Step
 
 Think of a capability token as a **boarding pass** for a specific flight:
@@ -80,7 +103,7 @@ Think of a capability token as a **boarding pass** for a specific flight:
 
 Only the claims the tool needs are disclosed; the rest are cryptographically hidden via SD-JWT selective disclosure.
 
-**Step 4 - Tool call with token.** The agent sends the HTTP request with the capability token in the `Authorization: SdJwt <token>` header. The tool server's inbound verification middleware:
+**Step 4 - Tool call with token.** The agent sends the HTTP request with the capability token in the `Authorization: Bearer <token>` header. The tool server's inbound verification middleware:
 
 1. Extracts the token from the header
 2. Verifies the SD-JWT signature against trusted issuer keys
@@ -105,7 +128,7 @@ sequenceDiagram
     Policy-->>Agent: Permit + constraints
     Agent->>Issuer: Mint SD-JWT capability token
     Issuer-->>Agent: token (short-lived, scoped)
-    Agent->>Tool: HTTP + Authorization: SdJwt <token>
+    Agent->>Tool: HTTP + Authorization: Bearer <token>
     Tool->>Verifier: Verify(token, expected aud, trusted keys)
     Verifier-->>Tool: Valid capability + context
     Tool->>Policy: Evaluate inbound action

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -4,6 +4,7 @@ Practical integration examples that combine multiple SD-JWT .NET packages in rea
 
 ## Agent Trust
 
+- [MCP Trust Demo](mcp-trust-demo.md): Full MCP tool marketplace demo with scripted and LLM-powered agents, showing SD-JWT trust gating in action.
 - [Agent Trust End-to-End](agent-trust-end-to-end.md): Agent runtime (MAF/MCP) mints capability SD-JWTs and ASP.NET Core tool API verifies and enforces them.
 - [Agent Trust PoC Use Cases](agent-trust-poc-usecases.md): Proof-of-concept scenarios with runnable code examples for capability token flows.
 - [Agent Trust PoC End-to-End](agent-trust-poc-e2e.md): Runnable end-to-end PoC with minimum implementation.

--- a/docs/examples/agent-trust-end-to-end.md
+++ b/docs/examples/agent-trust-end-to-end.md
@@ -59,7 +59,7 @@ var token = await mcpAdapter.MintForToolCallAsync(
     });
 
 using var http = new HttpClient();
-http.DefaultRequestHeaders.Add("Authorization", $"SdJwt {token.Token}");
+http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token.Token}");
 var response = await http.GetAsync("https://tools.example.com/ledger/entries");
 ```
 

--- a/docs/examples/agent-trust-poc-e2e.md
+++ b/docs/examples/agent-trust-poc-e2e.md
@@ -170,7 +170,7 @@ sequenceDiagram
 
   Note over Agent: Step 3: Call tool with token
 
-  Agent->>HTTP: GET /api/members/M-12345 [Authorization: SdJwt <token>]
+  Agent->>HTTP: GET /api/members/M-12345 [Authorization: Bearer <token>]
 
   Note over MW: Step 4: Inbound verification at tool server
 
@@ -872,7 +872,7 @@ public class AgentTrustMiddleware
             await context.Response.WriteAsJsonAsync(new
             {
                 error = "missing_capability_token",
-                message = "Authorization header with SdJwt token required"
+                message = "Authorization header with Bearer token required"
             });
             return;
         }
@@ -1174,10 +1174,10 @@ if (decision.IsPermitted)
 
     // Step 3: Call tool with token
     // In a real deployment, this would be an HTTP call:
-    //   httpClient.DefaultRequestHeaders.Add("Authorization", $"SdJwt {tokenResult.Token}");
+    //   httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {tokenResult.Token}");
     //   var response = await httpClient.GetAsync("http://member-lookup/api/members/M-12345");
 
-    logger.LogInformation("Token attached to request: Authorization: SdJwt <{Len} chars>",
+    logger.LogInformation("Token attached to request: Authorization: Bearer <{Len} chars>",
         tokenResult.Token.Length);
 
     // Step 4: Verify the token (simulating tool-side verification)
@@ -1313,7 +1313,7 @@ info: Policy rule 'Allow MemberLookup' matched: agent://claims-orchestrator -> M
 info: Policy: PERMIT (maxResults=50, lifetime=60s)
 info: Minted capability token abc123 for MemberLookup.GetProfile -> tool://member-lookup, expires 2026-03-01T14:01:00Z
 info: Minted token: id=abc123, expires=2026-03-01T14:01:00+00:00
-info: Token attached to request: Authorization: SdJwt <842 chars>
+info: Token attached to request: Authorization: Bearer <842 chars>
 info: Verified capability token abc123: MemberLookup.GetProfile from agent://claims-orchestrator
 info: VERIFIED: tool=MemberLookup, action=GetProfile, limits.maxResults=50
 info: AUDIT RECEIPT | Decision=Allow | Tool=MemberLookup | Action=GetProfile | TokenId=abc123 | CorrelationId=a1b2c3d4e5f6

--- a/docs/examples/agent-trust-poc-usecases.md
+++ b/docs/examples/agent-trust-poc-usecases.md
@@ -77,7 +77,7 @@ Console.WriteLine($"Expires: {tokenResult.ExpiresAt}");
 // === CALL: Attach token to HTTP request ===
 
 using var httpClient = new HttpClient();
-httpClient.DefaultRequestHeaders.Add("Authorization", $"SdJwt {tokenResult.Token}");
+httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {tokenResult.Token}");
 var response = await httpClient.GetAsync("https://tool-server/api/members/12345/fees");
 
 // === VERIFY: Tool-Side ===

--- a/docs/examples/mcp-trust-demo.md
+++ b/docs/examples/mcp-trust-demo.md
@@ -1,0 +1,411 @@
+# MCP Tool Marketplace with Agent Trust - Demo Guide
+
+## Document Information
+
+| Field   | Value                                                           |
+| ------- | --------------------------------------------------------------- |
+| Version | 1.0.0                                                           |
+| Status  | Active                                                          |
+| Created | 2026-04-30                                                      |
+| Related | [Agent Trust Integration](../guides/agent-trust-integration.md) |
+| Source  | `samples/McpTrustDemo/`                                         |
+
+---
+
+## Overview
+
+This demo showcases how SD-JWT capability tokens solve the MCP authorization gap. It includes two variants:
+
+| Variant             | Description                                                                                  |   AI Required    |
+| ------------------- | -------------------------------------------------------------------------------------------- | :--------------: |
+| **Scripted Client** | Deterministic 8-scenario demo covering authorization, denials, replay, and delegation        |        No        |
+| **LLM Client**      | OpenAI-powered agent where the LLM autonomously picks tools and the trust layer gates access | Yes (OpenAI key) |
+
+Both variants share the same MCP tool server with per-endpoint `McpServerTrustGuard` verification.
+
+---
+
+## Problem Statement
+
+MCP (Model Context Protocol) defines tool discovery and invocation but has **no built-in authorization model**. Any agent that reaches a tool server can call any tool without limits. This creates risk:
+
+- Privilege escalation across agent boundaries
+- No audit trail for tool invocations
+- Replay attacks with stolen tokens
+- Lateral movement between tool servers
+
+The Agent Trust Kit solves this by minting **scoped, time-limited SD-JWT capability tokens** for each tool call, verified cryptographically at the server.
+
+---
+
+## How Agent Trust Works
+
+Agent Trust extends SD-JWT from human-held verifiable credentials to **machine-to-machine agent capabilities**. Think of a capability token as a **boarding pass** - it authorizes one specific agent to perform one specific action on one specific tool, for a brief window.
+
+### The Capability Token
+
+Each token is a standard SD-JWT containing:
+
+| Claim        | Purpose                           | Example                                 |
+| ------------ | --------------------------------- | --------------------------------------- |
+| `iss`        | Who is calling (agent identity)   | `agent://enterprise-assistant`          |
+| `aud`        | Who is being called (tool server) | `https://mcp-tools.enterprise.local`    |
+| `cap.tool`   | Which tool                        | `sql_query`                             |
+| `cap.action` | What operation                    | `Read`                                  |
+| `cap.limits` | Optional constraints              | `{ maxResults: 100 }`                   |
+| `ctx`        | Correlation metadata              | `{ correlationId, workflowId, stepId }` |
+| `exp`        | Expiry (seconds to minutes)       | 30-120 seconds                          |
+| `jti`        | Unique ID for replay prevention   | UUID                                    |
+
+Only the claims the tool needs are disclosed; the rest remain cryptographically hidden via SD-JWT selective disclosure.
+
+### Five-Step Flow
+
+```
+Agent Task --> Policy Check --> Mint Token --> Call Tool --> Verify + Execute
+```
+
+1. **Task arrives** - The agent (LLM or scripted) determines it needs to call a tool.
+2. **Policy pre-flight** - The policy engine evaluates: _"Is agent X allowed to call tool Y with action Z?"_ If denied, the call never happens and the LLM receives an explanation.
+3. **Token minting** - `CapabilityTokenIssuer` creates a short-lived SD-JWT scoped to this exact call.
+4. **Tool invocation** - The HTTP request carries the token in a configurable header (this demo uses `Authorization` with a custom `SdJwt` scheme prefix). The server's `McpServerTrustGuard` verifies signature, issuer, audience, expiry, nonce, and tool binding.
+5. **Execute or reject** - If all checks pass, the tool executes. Otherwise the server returns 403 with a structured error.
+
+> **Note on token transport:** The `SdJwt` auth scheme is a project-defined convention, not a registered IANA HTTP authentication scheme. The header name and prefix are configurable via `AgentTrustVerificationOptions.TokenHeaderName` / `TokenHeaderPrefix`. The MCP client module defaults to a custom `X-Agent-Trust-Token` header instead. Choose whatever fits your deployment (e.g., `Bearer` with a resource-server that understands SD-JWT, or a custom header for MCP metadata propagation).
+
+### Dual Enforcement (Defense in Depth)
+
+```
+CLIENT SIDE                           SERVER SIDE
++-----------------------+             +-----------------------+
+| PolicyEngine.Evaluate |             | McpServerTrustGuard   |
+| - Match allow rules   |             | - Verify SD-JWT sig   |
+| - Check deny rules    |             | - Check aud matches   |
+| - Reject if no match  |             | - Validate exp/nonce  |
++-----------------------+             | - Re-evaluate policy  |
+         |                            +-----------------------+
+         | (only if allowed)                    |
+         v                                      v
+  Mint SD-JWT token ----HTTP----> Verify token + Execute
+```
+
+The client enforces policy before minting (fail-fast, saves network round trips). The server re-verifies independently (zero trust - never assumes the client is honest).
+
+### Policy Model
+
+Rules follow the pattern `(agent, tool, action)` with explicit deny taking priority:
+
+- **Allow rules** grant access to specific triples, optionally with constraints (max lifetime, result limits, required disclosures)
+- **Deny rules** block access regardless of allow rules
+- **Evaluation order:** Deny first, then allow. No match = implicit deny.
+
+### Agent-to-Agent Delegation
+
+When an orchestrator delegates to a sub-agent, the delegation token includes:
+
+- The original issuer chain (who started the request)
+- Maximum delegation depth (prevents unbounded chains)
+- Scope attenuation (sub-agent can only receive equal or lesser permissions)
+
+This prevents privilege escalation through multi-hop delegation.
+
+### Why SD-JWT (not plain JWT)?
+
+| Feature               | Plain JWT                   | SD-JWT Capability Token              |
+| --------------------- | --------------------------- | ------------------------------------ |
+| Selective disclosure  | All claims visible          | Only disclose what tool needs        |
+| Unlinkability         | Verifier sees full identity | Verifier sees only scoped capability |
+| Minimal data exposure | Full payload always sent    | Privacy-preserving by default        |
+
+For a complete treatment see [Agent Trust Kits Deep Dive](../concepts/agent-trust-kits-deep-dive.md).
+
+---
+
+## Architecture
+
+```
++---------------------------------------------------------+
+|  AI Agent (LLM or Scripted)                             |
+|                                                         |
+|  1. User asks a question                                |
+|  2. Agent decides which tool to call                    |
+|  3. McpClientTrustInterceptor:                          |
+|     a) Policy pre-flight check (allow/deny)             |
+|     b) Mint SD-JWT capability token (if allowed)        |
+|     c) Attach token header (configurable scheme)        |
++---------------------------------------------------------+
+           |
+           |  HTTP POST /tools/{name}
+           |  Authorization: Bearer eyJ...~...  (RFC 6750)
+           v
++---------------------------------------------------------+
+|  MCP Tool Server (ASP.NET Core)                         |
+|                                                         |
+|  4. McpServerTrustGuard:                                |
+|     a) Verify signature (HS256 shared key)              |
+|     b) Validate issuer against TrustedIssuers           |
+|     c) Check audience matches tool server               |
+|     d) Enforce replay prevention (nonce store)          |
+|     e) Validate tool-name matches token cap.tool        |
+|     f) Evaluate server-side policy                      |
+|                                                         |
+|  5. Execute tool (if verified) or return 403            |
++---------------------------------------------------------+
+```
+
+---
+
+## Demo Scenarios (Scripted Client)
+
+| #   | Scenario                  | Agent                  | Tool                    | Result               |
+| --- | ------------------------- | ---------------------- | ----------------------- | -------------------- |
+| 1   | Authorized access         | Data Analyst           | sql_query (Read)        | HTTP 200             |
+| 2   | Authorized access         | Customer Support       | customer_lookup (Read)  | HTTP 200             |
+| 3   | Authorized access         | Code Assistant         | code_executor (Execute) | HTTP 200             |
+| 4   | Cross-boundary denial     | Data Analyst           | email_sender (Send)     | Client-side deny     |
+| 5   | Action denial             | Code Assistant         | file_browser (Delete)   | Client-side deny     |
+| 6   | Sensitive resource denial | Data Analyst           | secrets_vault (Read)    | Client-side deny     |
+| 7   | Replay attack prevention  | Data Analyst           | sql_query (reuse token) | HTTP 403             |
+| 8   | Agent-to-agent delegation | Orchestrator -> Worker | sql_query (Read)        | HTTP 200 (delegated) |
+
+---
+
+## Demo Scenarios (LLM Client)
+
+| #   | Prompt                          | LLM Decision                               | Trust Result                                  |
+| --- | ------------------------------- | ------------------------------------------ | --------------------------------------------- |
+| 1   | "Show me Engineering employees" | Calls `sql_query`                          | Allowed - data returned                       |
+| 2   | "Look up Acme Corporation"      | Calls `customer_lookup`                    | Allowed - data returned                       |
+| 3   | "List files in /reports"        | Calls `file_browser`                       | Allowed - data returned                       |
+| 4   | "Send email to bob@..."         | Calls `email_sender` (or asks for details) | Denied by policy                              |
+| 5   | "Execute Python code"           | Calls `code_executor`                      | Denied by rule `deny:*:code_executor:Execute` |
+| 6   | "Read database password"        | Calls `secrets_vault` (or refuses)         | Denied by rule `deny:*:secrets_vault:*`       |
+
+The LLM receives the denial reason and explains to the user why the action is blocked.
+
+---
+
+## Running the Demo
+
+### Prerequisites
+
+- .NET 9.0+ SDK
+- For LLM variant: OpenAI API key with available quota
+
+### Scripted Client (no AI required)
+
+```pwsh
+# Terminal 1: Start the MCP tool server
+dotnet run --project samples/McpTrustDemo/McpTrustDemo.Server
+
+# Terminal 2: Run the scripted demo
+dotnet run --project samples/McpTrustDemo/McpTrustDemo.Client
+```
+
+### LLM Client (requires OpenAI key)
+
+```pwsh
+# Terminal 1: Start the MCP tool server
+dotnet run --project samples/McpTrustDemo/McpTrustDemo.Server
+
+# Terminal 2: Run the LLM agent
+$env:OPENAI_API_KEY = "sk-..."
+dotnet run --project samples/McpTrustDemo/McpTrustDemo.Llm
+```
+
+### Environment Variables (LLM variant)
+
+| Variable         | Default                 | Description                |
+| ---------------- | ----------------------- | -------------------------- |
+| `OPENAI_API_KEY` | (required)              | OpenAI API key             |
+| `OPENAI_MODEL`   | `gpt-4o-mini`           | Model for function calling |
+| `MCP_SERVER_URL` | `http://localhost:5100` | MCP tool server URL        |
+
+---
+
+## Policy Configuration
+
+Both client and server use a declarative `PolicyBuilder`:
+
+```csharp
+// Scripted client: role-based policies per agent
+new PolicyBuilder()
+    .Allow("agent://data-analyst", "sql_query", "Read")
+    .Allow("agent://data-analyst", "file_browser", "Read")
+    .Allow("agent://customer-support", "customer_lookup", "Read")
+    .Allow("agent://customer-support", "email_sender", "Send")
+    .Allow("agent://code-assistant", "file_browser", "Read")
+    .Allow("agent://code-assistant", "code_executor", "Execute")
+    .Deny("*", "*", "Delete")
+    .Deny("*", "secrets_vault", "*")
+    .Build();
+
+// LLM client: single agent with read-only scope
+new PolicyBuilder()
+    .Allow("agent://enterprise-assistant", "sql_query", "Read")
+    .Allow("agent://enterprise-assistant", "customer_lookup", "Read")
+    .Allow("agent://enterprise-assistant", "file_browser", "Read")
+    .Deny("*", "secrets_vault", "*")
+    .Deny("*", "*", "Delete")
+    .Deny("*", "code_executor", "Execute")
+    .Build();
+```
+
+Policy evaluation order: explicit deny rules take priority, then allow rules must match.
+
+---
+
+## Key Implementation Patterns
+
+### 1. Token Minting (Client Side)
+
+The `McpClientTrustInterceptor` handles policy evaluation and token minting:
+
+```csharp
+var interceptor = new McpClientTrustInterceptor(
+    new CapabilityTokenIssuer(signingKey, SecurityAlgorithms.HmacSha256, nonceStore),
+    policyEngine,
+    new McpClientTrustOptions
+    {
+        AgentId = "agent://enterprise-assistant",
+        ToolAudienceMapping = new Dictionary<string, string>
+        {
+            ["sql_query"] = "https://mcp-tools.enterprise.local",
+            ["customer_lookup"] = "https://mcp-tools.enterprise.local"
+        },
+        DefaultTokenLifetime = TimeSpan.FromSeconds(60)
+    });
+
+// For each tool call:
+var result = await interceptor.BeforeToolCallAsync(new McpToolCall
+{
+    ToolName = "sql_query",
+    Action = "Read",
+    Context = new CapabilityContext
+    {
+        CorrelationId = Guid.NewGuid().ToString("N"),
+        WorkflowId = "llm-agent-session"
+    }
+});
+
+// result.Token contains the SD-JWT to attach as Authorization header
+```
+
+### 2. Token Verification (Server Side)
+
+Per-endpoint verification with `McpServerTrustGuard`:
+
+```csharp
+app.MapPost("/tools/sql_query", async (HttpContext context, McpServerTrustGuard guard) =>
+{
+    var token = context.Request.Headers["Authorization"]
+        .ToString().Replace("Bearer ", "");
+
+    var result = await guard.VerifyToolCallAsync("sql_query", token);
+
+    if (!result.IsValid)
+        return Results.Json(new { error = result.Error, code = result.ErrorCode },
+            statusCode: 403);
+
+    // Execute tool...
+    return Results.Ok(new { tool = "sql_query", data = "..." });
+});
+```
+
+### 3. LLM Function Calling with Trust Gating
+
+The LLM agent uses `Microsoft.Extensions.AI` with `AIFunctionFactory`:
+
+```csharp
+// Define tools for the LLM (schema only - execution goes through trust layer)
+var tools = new[]
+{
+    AIFunctionFactory.Create(
+        (string query) => "placeholder",
+        new AIFunctionFactoryOptions
+        {
+            Name = "sql_query",
+            Description = "Execute a SQL query against the database."
+        }),
+    // ... more tools
+};
+
+// When LLM produces a FunctionCallContent:
+var trustResult = await toolExecutor.ExecuteAsync(
+    functionCall.Name,    // tool the LLM chose
+    DeriveAction(name),   // Read/Send/Execute based on tool type
+    functionCall.Arguments);
+
+// Feed result (or denial) back to LLM as FunctionResultContent
+messages.Add(new ChatMessage(ChatRole.Tool,
+    [new FunctionResultContent(functionCall.CallId, trustResult.Data ?? trustResult.Error)]));
+```
+
+---
+
+## Security Properties Demonstrated
+
+| Property                | How it works                                                     |
+| ----------------------- | ---------------------------------------------------------------- |
+| **Least privilege**     | Each agent/tool/action triple requires an explicit allow rule    |
+| **Time-limited tokens** | Tokens expire in 30-120 seconds (configurable per rule)          |
+| **Single-use tokens**   | `MemoryNonceStore` tracks consumed JTIs; replay returns 403      |
+| **Audience binding**    | Token `aud` must match the tool server's configured audience     |
+| **Issuer verification** | Server only accepts tokens from agents in `TrustedIssuers` map   |
+| **Tool-name binding**   | Token's `cap.tool` must match the endpoint being called          |
+| **Dual enforcement**    | Client pre-flight AND server verification (defense in depth)     |
+| **Delegation depth**    | A2A tokens are depth-limited with cryptographic hop verification |
+
+---
+
+## Observability
+
+Both client and server emit OpenTelemetry metrics:
+
+| Metric                           | Description               |
+| -------------------------------- | ------------------------- |
+| `agent_trust.tokens.minted`      | Tokens issued by client   |
+| `agent_trust.tokens.verified`    | Tokens verified by server |
+| `agent_trust.tokens.rejected`    | Verification failures     |
+| `agent_trust.policy.evaluations` | Total policy evaluations  |
+| `agent_trust.policy.denials`     | Policy denial count       |
+
+Console exporters are enabled in the demo. In production, these route to Azure Monitor, Prometheus, or any OTLP-compatible backend.
+
+---
+
+## Packages Used
+
+| Package                              | Role                                                                                      |
+| ------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `SdJwt.Net.AgentTrust.Core`          | Token minting (`CapabilityTokenIssuer`) and verification (`CapabilityTokenVerifier`)      |
+| `SdJwt.Net.AgentTrust.Policy`        | Rule-based policy engine (`PolicyBuilder`, `DefaultPolicyEngine`)                         |
+| `SdJwt.Net.AgentTrust.Mcp`           | Client interceptor (`McpClientTrustInterceptor`) and server guard (`McpServerTrustGuard`) |
+| `SdJwt.Net.AgentTrust.AspNetCore`    | ASP.NET Core middleware for the tool server                                               |
+| `SdJwt.Net.AgentTrust.A2A`           | Agent-to-agent delegation                                                                 |
+| `SdJwt.Net.AgentTrust.OpenTelemetry` | Metrics instrumentation                                                                   |
+| `Microsoft.Extensions.AI.OpenAI`     | OpenAI integration via `IChatClient` (LLM variant only)                                   |
+
+---
+
+## Production Considerations
+
+| Concern           | Demo Approach         | Production Approach                               |
+| ----------------- | --------------------- | ------------------------------------------------- |
+| Key management    | Shared HS256 key      | Asymmetric keys in Azure Key Vault                |
+| Key discovery     | Hardcoded             | JWKS endpoint with rotation                       |
+| Replay prevention | In-memory nonce store | Distributed store (Redis)                         |
+| Policy management | Code-defined rules    | OPA via `SdJwt.Net.AgentTrust.Policy.Opa`         |
+| Observability     | Console exporter      | Azure Monitor / Prometheus + Grafana              |
+| Agent identity    | String-based IDs      | Workload Identity (SPIFFE/Entra)                  |
+| Multi-tenancy     | Single tenant         | `CapabilityContext.TenantId` with scoped policies |
+
+---
+
+## Further Reading
+
+- [Agent Trust Integration Guide](../guides/agent-trust-integration.md)
+- [Agent Trust Kits Deep Dive](../concepts/agent-trust-kits-deep-dive.md)
+- [Agent Trust PoC End-to-End](agent-trust-poc-e2e.md)
+- [SD-JWT RFC 9901](https://www.rfc-editor.org/rfc/rfc9901)
+- [Model Context Protocol](https://modelcontextprotocol.io/)

--- a/docs/guides/agent-trust-integration.md
+++ b/docs/guides/agent-trust-integration.md
@@ -73,7 +73,7 @@ var tokenResult = await adapter.MintForToolCallAsync(
 Use `tokenResult.Token` in the outbound tool call header:
 
 - Header: `Authorization`
-- Value: `SdJwt <token>`
+- Value: `Bearer <token>`
 
 ---
 

--- a/docs/tutorials/intermediate/07-agent-trust-kits.md
+++ b/docs/tutorials/intermediate/07-agent-trust-kits.md
@@ -98,7 +98,7 @@ public IActionResult GetInvoice(string id) => Ok();
 Set request header:
 
 ```text
-Authorization: SdJwt <tokenResult.Token>
+Authorization: Bearer <tokenResult.Token>
 ```
 
 If verification and policy checks pass, the request continues to your endpoint.

--- a/samples/McpTrustDemo/McpTrustDemo.Client/AgentRegistry.cs
+++ b/samples/McpTrustDemo/McpTrustDemo.Client/AgentRegistry.cs
@@ -1,0 +1,26 @@
+namespace McpTrustDemo.Client;
+
+/// <summary>
+/// Represents an AI agent with bounded capabilities.
+/// </summary>
+/// <param name="AgentId">Unique agent identifier URI.</param>
+/// <param name="DisplayName">Human-readable name.</param>
+/// <param name="AllowedTools">Tools this agent is configured to use.</param>
+public record AgentProfile(string AgentId, string DisplayName, string[] AllowedTools);
+
+/// <summary>
+/// Registry of available agent profiles.
+/// </summary>
+public class AgentRegistry
+{
+    private readonly IReadOnlyDictionary<string, AgentProfile> _agents;
+
+    public AgentRegistry(IReadOnlyDictionary<string, AgentProfile> agents)
+    {
+        _agents = agents;
+    }
+
+    public AgentProfile Get(string name) => _agents[name];
+
+    public IEnumerable<AgentProfile> All => _agents.Values;
+}

--- a/samples/McpTrustDemo/McpTrustDemo.Client/DemoOrchestrator.cs
+++ b/samples/McpTrustDemo/McpTrustDemo.Client/DemoOrchestrator.cs
@@ -1,0 +1,327 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using SdJwt.Net.AgentTrust.Core;
+using SdJwt.Net.AgentTrust.Mcp;
+using SdJwt.Net.AgentTrust.Policy;
+using System.Text.Json;
+
+namespace McpTrustDemo.Client;
+
+/// <summary>
+/// Orchestrates the demo scenarios showing different agents attempting
+/// tool calls with varying levels of authorization.
+/// </summary>
+public class DemoOrchestrator
+{
+    private readonly AgentRegistry _registry;
+    private readonly IPolicyEngine _policyEngine;
+    private readonly INonceStore _nonceStore;
+    private readonly SymmetricSecurityKey _signingKey;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<DemoOrchestrator> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public DemoOrchestrator(
+        AgentRegistry registry,
+        IPolicyEngine policyEngine,
+        INonceStore nonceStore,
+        SymmetricSecurityKey signingKey,
+        IHttpClientFactory httpClientFactory,
+        ILogger<DemoOrchestrator> logger)
+    {
+        _registry = registry;
+        _policyEngine = policyEngine;
+        _nonceStore = nonceStore;
+        _signingKey = signingKey;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task RunDemoAsync()
+    {
+        // Scenario 1: Authorized tool calls succeed
+        await RunScenario("1. Authorized Access - Data Analyst queries SQL",
+            "data-analyst", "sql_query", "Read",
+            expectSuccess: true);
+
+        // Scenario 2: Authorized tool calls succeed
+        await RunScenario("2. Authorized Access - Customer Support looks up customer",
+            "customer-support", "customer_lookup", "Read",
+            expectSuccess: true);
+
+        // Scenario 3: Authorized tool calls succeed
+        await RunScenario("3. Authorized Access - Code Assistant executes code",
+            "code-assistant", "code_executor", "Execute",
+            expectSuccess: true);
+
+        // Scenario 4: Cross-boundary denial (analyst tries to send email)
+        await RunScenario("4. Cross-Boundary Denial - Data Analyst tries email_sender",
+            "data-analyst", "email_sender", "Send",
+            expectSuccess: false);
+
+        // Scenario 5: Action denial (any agent tries Delete)
+        await RunScenario("5. Action Denial - Code Assistant tries Delete on file_browser",
+            "code-assistant", "file_browser", "Delete",
+            expectSuccess: false);
+
+        // Scenario 6: Sensitive resource denial (agent tries secrets)
+        await RunScenario("6. Sensitive Resource Denial - Data Analyst tries secrets_vault",
+            "data-analyst", "secrets_vault", "Read",
+            expectSuccess: false);
+
+        // Scenario 7: Replay attack prevention
+        await RunReplayScenario();
+
+        // Scenario 8: Multi-agent workflow (orchestrator delegates)
+        await RunDelegationScenario();
+    }
+
+    private async Task RunScenario(
+        string title,
+        string agentName,
+        string toolName,
+        string action,
+        bool expectSuccess)
+    {
+        Console.WriteLine($"--- {title} ---");
+
+        var agent = _registry.Get(agentName);
+        Console.WriteLine($"  Agent: {agent.DisplayName} ({agent.AgentId})");
+        Console.WriteLine($"  Tool: {toolName}, Action: {action}");
+
+        var interceptor = new McpClientTrustInterceptor(
+            new CapabilityTokenIssuer(_signingKey, SecurityAlgorithms.HmacSha256, _nonceStore),
+            _policyEngine,
+            new McpClientTrustOptions
+            {
+                AgentId = agent.AgentId,
+                ToolAudienceMapping = new Dictionary<string, string>
+                {
+                    [toolName] = "https://mcp-tools.enterprise.local"
+                },
+                DefaultTokenLifetime = TimeSpan.FromSeconds(60)
+            });
+
+        var toolCall = new McpToolCall
+        {
+            ToolName = toolName,
+            Action = action,
+            Context = new CapabilityContext
+            {
+                CorrelationId = Guid.NewGuid().ToString("N"),
+                WorkflowId = $"demo-{agentName}-{toolName}"
+            }
+        };
+
+        var mintResult = await interceptor.BeforeToolCallAsync(toolCall);
+
+        if (!mintResult.IsSuccess)
+        {
+            Console.ForegroundColor = expectSuccess ? ConsoleColor.Red : ConsoleColor.Yellow;
+            Console.WriteLine($"  DENIED (client-side): {mintResult.Error}");
+            Console.ResetColor();
+
+            if (!expectSuccess)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine("  [EXPECTED] Policy correctly blocked unauthorized access.");
+                Console.ResetColor();
+            }
+
+            Console.WriteLine();
+            return;
+        }
+
+        // Call the MCP tool server with the minted token
+        var client = _httpClientFactory.CreateClient("McpToolServer");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/tools/{toolName}");
+        request.Headers.Add("Authorization", $"Bearer {mintResult.Token}");
+        request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+
+        var response = await client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        if (response.IsSuccessStatusCode)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"  SUCCESS (HTTP {(int)response.StatusCode})"); ;
+            Console.ResetColor();
+
+            var formatted = FormatJson(body);
+            Console.WriteLine($"  Response: {formatted}");
+        }
+        else
+        {
+            Console.ForegroundColor = expectSuccess ? ConsoleColor.Red : ConsoleColor.Yellow;
+            Console.WriteLine($"  REJECTED (HTTP {(int)response.StatusCode}): {body}");
+            Console.ResetColor();
+
+            if (!expectSuccess)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine("  [EXPECTED] Server correctly rejected the request.");
+                Console.ResetColor();
+            }
+        }
+
+        Console.WriteLine();
+    }
+
+    private async Task RunReplayScenario()
+    {
+        Console.WriteLine("--- 7. Replay Attack Prevention ---");
+        Console.WriteLine("  Minting a token and using it twice to prove replay protection.");
+
+        var agent = _registry.Get("data-analyst");
+        var interceptor = new McpClientTrustInterceptor(
+            new CapabilityTokenIssuer(_signingKey, SecurityAlgorithms.HmacSha256, _nonceStore),
+            _policyEngine,
+            new McpClientTrustOptions
+            {
+                AgentId = agent.AgentId,
+                ToolAudienceMapping = new Dictionary<string, string>
+                {
+                    ["sql_query"] = "https://mcp-tools.enterprise.local"
+                }
+            });
+
+        var toolCall = new McpToolCall
+        {
+            ToolName = "sql_query",
+            Action = "Read",
+            Context = new CapabilityContext
+            {
+                CorrelationId = Guid.NewGuid().ToString("N"),
+                WorkflowId = "demo-replay-test"
+            }
+        };
+
+        var mintResult = await interceptor.BeforeToolCallAsync(toolCall);
+        if (!mintResult.IsSuccess)
+        {
+            Console.WriteLine($"  Failed to mint: {mintResult.Error}");
+            Console.WriteLine();
+            return;
+        }
+
+        Console.WriteLine($"  Token minted: {mintResult.TokenId}");
+
+        // First use - should succeed
+        var client = _httpClientFactory.CreateClient("McpToolServer");
+        var request1 = new HttpRequestMessage(HttpMethod.Post, "/tools/sql_query");
+        request1.Headers.Add("Authorization", $"Bearer {mintResult.Token}");
+        request1.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+
+        var response1 = await client.SendAsync(request1);
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine($"  First use: HTTP {(int)response1.StatusCode} (authorized)");
+        Console.ResetColor();
+
+        // Second use (replay) - should be rejected
+        var request2 = new HttpRequestMessage(HttpMethod.Post, "/tools/sql_query");
+        request2.Headers.Add("Authorization", $"Bearer {mintResult.Token}");
+        request2.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+
+        var response2 = await client.SendAsync(request2);
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine($"  Replay attempt: HTTP {(int)response2.StatusCode} (rejected - replay detected)");
+        Console.ResetColor();
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine("  [EXPECTED] Server detected token reuse and blocked the replay attack.");
+        Console.ResetColor();
+        Console.WriteLine();
+    }
+
+    private async Task RunDelegationScenario()
+    {
+        Console.WriteLine("--- 8. Agent-to-Agent Delegation (A2A) ---");
+        Console.WriteLine("  Orchestrator agent delegates scoped capability to worker agent.");
+        Console.WriteLine();
+
+        // Orchestrator mints a token for itself
+        var orchestratorIssuer = new CapabilityTokenIssuer(
+            _signingKey, SecurityAlgorithms.HmacSha256, _nonceStore);
+
+        // Orchestrator delegates a read-only subset to data-analyst
+        var delegationIssuer = new SdJwt.Net.AgentTrust.A2A.A2ADelegationIssuer(
+            orchestratorIssuer, _policyEngine);
+
+        try
+        {
+            var delegationResult = await delegationIssuer.DelegateAsync(
+                new SdJwt.Net.AgentTrust.A2A.A2ADelegationOptions
+                {
+                    Issuer = "agent://orchestrator",
+                    Audience = "https://mcp-tools.enterprise.local",
+                    Capability = new CapabilityClaim
+                    {
+                        Tool = "sql_query",
+                        Action = "Read",
+                        Resource = "customers/*"
+                    },
+                    Context = new CapabilityContext
+                    {
+                        CorrelationId = Guid.NewGuid().ToString("N"),
+                        WorkflowId = "demo-delegation-workflow",
+                        TenantId = "tenant-acme"
+                    },
+                    Lifetime = TimeSpan.FromSeconds(30),
+                    Delegation = new SdJwt.Net.AgentTrust.Policy.DelegationChain
+                    {
+                        DelegatedBy = "agent://orchestrator",
+                        Depth = 0,
+                        MaxDepth = 2
+                    }
+                });
+
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"  Delegation token minted: {delegationResult.TokenId}");
+            Console.WriteLine($"  Expires: {delegationResult.ExpiresAt:O}");
+            Console.ResetColor();
+
+            // Use delegated token to call the server
+            var client = _httpClientFactory.CreateClient("McpToolServer");
+            var request = new HttpRequestMessage(HttpMethod.Post, "/tools/sql_query");
+            request.Headers.Add("Authorization", $"Bearer {delegationResult.Token}");
+            request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+
+            var response = await client.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+
+            Console.WriteLine($"  Delegated call result: HTTP {(int)response.StatusCode}");
+            if (response.IsSuccessStatusCode)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine("  [SUCCESS] Delegated token accepted by server.");
+                Console.ResetColor();
+            }
+
+            Console.WriteLine($"  Response: {FormatJson(body)}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine($"  Delegation blocked: {ex.Message}");
+            Console.ResetColor();
+        }
+
+        Console.WriteLine();
+    }
+
+    private static string FormatJson(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return JsonSerializer.Serialize(doc, JsonOptions);
+        }
+        catch
+        {
+            return json;
+        }
+    }
+}

--- a/samples/McpTrustDemo/McpTrustDemo.Client/McpTrustDemo.Client.csproj
+++ b/samples/McpTrustDemo/McpTrustDemo.Client/McpTrustDemo.Client.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework Condition="'$(NETCoreSdkVersion)' >= '10.0.0'">net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>McpTrustDemo.Client</RootNamespace>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference
+      Include="..\..\..\src\SdJwt.Net.AgentTrust.Core\SdJwt.Net.AgentTrust.Core.csproj" />
+    <ProjectReference
+      Include="..\..\..\src\SdJwt.Net.AgentTrust.Policy\SdJwt.Net.AgentTrust.Policy.csproj" />
+    <ProjectReference
+      Include="..\..\..\src\SdJwt.Net.AgentTrust.Mcp\SdJwt.Net.AgentTrust.Mcp.csproj" />
+    <ProjectReference
+      Include="..\..\..\src\SdJwt.Net.AgentTrust.A2A\SdJwt.Net.AgentTrust.A2A.csproj" />
+    <ProjectReference
+      Include="..\..\..\src\SdJwt.Net.AgentTrust.OpenTelemetry\SdJwt.Net.AgentTrust.OpenTelemetry.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/McpTrustDemo/McpTrustDemo.Client/Program.cs
+++ b/samples/McpTrustDemo/McpTrustDemo.Client/Program.cs
@@ -1,0 +1,96 @@
+using McpTrustDemo.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using SdJwt.Net.AgentTrust.Core;
+using SdJwt.Net.AgentTrust.Mcp;
+using SdJwt.Net.AgentTrust.OpenTelemetry;
+using SdJwt.Net.AgentTrust.Policy;
+using System.Text;
+
+// -------------------------------------------------------------------
+// MCP Trust Demo Client
+// Simulates multiple AI agents calling an MCP Tool Server with
+// capability tokens for bounded authority.
+// -------------------------------------------------------------------
+
+Console.WriteLine("=============================================================");
+Console.WriteLine("  MCP Tool Marketplace with Agent Trust - Client Demo");
+Console.WriteLine("  Demonstrates: SD-JWT capability tokens for MCP tool access");
+Console.WriteLine("=============================================================");
+Console.WriteLine();
+
+var serverUrl = args.Length > 0 ? args[0] : "http://localhost:5100";
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureLogging(logging =>
+    {
+        logging.SetMinimumLevel(LogLevel.Warning);
+        logging.AddFilter("McpTrustDemo", LogLevel.Information);
+    })
+    .ConfigureServices(services =>
+    {
+        // Shared signing key (must match server)
+        var sharedKeyBytes = Encoding.UTF8.GetBytes("McpTrustDemoSigningKey-32Bytes!!");
+        var signingKey = new SymmetricSecurityKey(sharedKeyBytes);
+
+        // Nonce store for replay prevention
+        var nonceStore = new MemoryNonceStore();
+        services.AddSingleton<INonceStore>(nonceStore);
+
+        // Policy engine (client-side pre-flight check)
+        var policyEngine = new DefaultPolicyEngine(
+            new PolicyBuilder()
+                .Allow("agent://data-analyst", "sql_query", "Read")
+                .Allow("agent://data-analyst", "file_browser", "Read")
+                .Allow("agent://customer-support", "customer_lookup", "Read")
+                .Allow("agent://customer-support", "email_sender", "Send")
+                .Allow("agent://code-assistant", "file_browser", "Read")
+                .Allow("agent://code-assistant", "code_executor", "Execute")
+                .Allow("agent://orchestrator", "sql_query", "Read")
+                .Deny("*", "*", "Delete")
+                .Deny("*", "secrets_vault", "*")
+                .Build());
+
+        services.AddSingleton<IPolicyEngine>(policyEngine);
+        services.AddSingleton(signingKey);
+
+        // Register agent profiles
+        services.AddSingleton(new AgentRegistry(new Dictionary<string, AgentProfile>
+        {
+            ["data-analyst"] = new("agent://data-analyst", "Data Analyst Agent",
+                new[] { "sql_query", "file_browser" }),
+            ["customer-support"] = new("agent://customer-support", "Customer Support Agent",
+                new[] { "customer_lookup", "email_sender" }),
+            ["code-assistant"] = new("agent://code-assistant", "Code Assistant Agent",
+                new[] { "file_browser", "code_executor" })
+        }));
+
+        services.AddHttpClient("McpToolServer", client =>
+        {
+            client.BaseAddress = new Uri(serverUrl);
+        });
+
+        // OpenTelemetry
+        services.AddOpenTelemetry()
+            .WithTracing(tracing => tracing
+                .AddAgentTrustInstrumentation()
+                .AddConsoleExporter())
+            .WithMetrics(metrics => metrics
+                .AddAgentTrustInstrumentation()
+                .AddConsoleExporter());
+
+        services.AddSingleton<DemoOrchestrator>();
+    })
+    .Build();
+
+var orchestrator = host.Services.GetRequiredService<DemoOrchestrator>();
+await orchestrator.RunDemoAsync();
+
+Console.WriteLine();
+Console.WriteLine("=============================================================");
+Console.WriteLine("  Demo complete. All scenarios executed.");
+Console.WriteLine("=============================================================");

--- a/samples/McpTrustDemo/McpTrustDemo.Llm/LlmAgentRunner.cs
+++ b/samples/McpTrustDemo/McpTrustDemo.Llm/LlmAgentRunner.cs
@@ -1,0 +1,272 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using System.ComponentModel;
+using System.Text.Json;
+
+namespace McpTrustDemo.Llm;
+
+/// <summary>
+/// Runs an interactive LLM agent loop with trust-gated tool calling.
+/// The LLM decides which tools to invoke; the trust layer enforces
+/// whether the call is permitted via SD-JWT capability tokens.
+/// </summary>
+public class LlmAgentRunner
+{
+    private readonly IChatClient _chatClient;
+    private readonly TrustedToolExecutor _toolExecutor;
+    private readonly ILogger<LlmAgentRunner> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    public LlmAgentRunner(
+        IChatClient chatClient,
+        TrustedToolExecutor toolExecutor,
+        ILogger<LlmAgentRunner> logger)
+    {
+        _chatClient = chatClient;
+        _toolExecutor = toolExecutor;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Runs the interactive agent loop with preset demo prompts and
+    /// an optional interactive mode.
+    /// </summary>
+    public async Task RunInteractiveAsync()
+    {
+        var tools = CreateToolDefinitions();
+
+        var systemPrompt = """
+            You are an enterprise AI assistant with access to the following MCP tools:
+            - sql_query: Query employee and business data (action: Read)
+            - customer_lookup: Look up customer information (action: Read)
+            - file_browser: Browse and read files (action: Read)
+            - email_sender: Send emails (action: Send)
+            - code_executor: Execute code snippets (action: Execute)
+            - secrets_vault: Access secrets and credentials (action: Read)
+
+            When a user asks a question, decide which tool(s) to call.
+            You MUST use the available tools to answer questions - do not make up data.
+            If a tool call is denied by the trust layer, explain to the user that
+            you don't have permission for that action and suggest alternatives.
+            """;
+
+        // Run through demo scenarios first
+        var demoPrompts = new[]
+        {
+            "Show me all employees in the Engineering department.",
+            "Look up the details for our customer Acme Corporation.",
+            "List the files in the /reports directory.",
+            "Send an email to bob@example.com about the quarterly report.",
+            "Execute this Python code: print('hello world')",
+            "Read the database password from the secrets vault."
+        };
+
+        Console.WriteLine("Running demo scenarios (LLM picks tools, trust layer gates):");
+        Console.WriteLine("-------------------------------------------------------------");
+        Console.WriteLine();
+
+        foreach (var prompt in demoPrompts)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine($"User: {prompt}");
+            Console.ResetColor();
+            Console.WriteLine();
+
+            await RunSingleTurnAsync(systemPrompt, prompt, tools);
+
+            Console.WriteLine();
+            Console.WriteLine("---");
+            Console.WriteLine();
+        }
+
+        // Interactive mode
+        Console.WriteLine("=============================================================");
+        Console.WriteLine("  Interactive mode - type a question or 'quit' to exit");
+        Console.WriteLine("=============================================================");
+        Console.WriteLine();
+
+        while (true)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.Write("You: ");
+            Console.ResetColor();
+
+            var input = Console.ReadLine();
+            if (string.IsNullOrWhiteSpace(input) || input.Equals("quit", StringComparison.OrdinalIgnoreCase))
+                break;
+
+            Console.WriteLine();
+            await RunSingleTurnAsync(systemPrompt, input, tools);
+            Console.WriteLine();
+        }
+    }
+
+    private async Task RunSingleTurnAsync(string systemPrompt, string userMessage, IList<AITool> tools)
+    {
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, systemPrompt),
+            new(ChatRole.User, userMessage)
+        };
+
+        var options = new ChatOptions { Tools = tools };
+
+        // LLM may produce multiple rounds of tool calls
+        const int maxRounds = 5;
+        for (var round = 0; round < maxRounds; round++)
+        {
+            ChatResponse response;
+            try
+            {
+                response = await _chatClient.GetResponseAsync(messages, options);
+            }
+            catch (Exception ex)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"  LLM error: {ex.Message}");
+                Console.ResetColor();
+                return;
+            }
+
+            // Process response messages
+            var hasToolCalls = false;
+            foreach (var msg in response.Messages)
+            {
+                messages.Add(msg);
+
+                foreach (var content in msg.Contents)
+                {
+                    if (content is FunctionCallContent functionCall)
+                    {
+                        hasToolCalls = true;
+                        await HandleToolCallAsync(functionCall, messages);
+                    }
+                    else if (content is TextContent text && !string.IsNullOrWhiteSpace(text.Text))
+                    {
+                        Console.ForegroundColor = ConsoleColor.White;
+                        Console.WriteLine($"  Assistant: {text.Text}");
+                        Console.ResetColor();
+                    }
+                }
+            }
+
+            if (!hasToolCalls)
+                break;
+        }
+    }
+
+    private async Task HandleToolCallAsync(FunctionCallContent functionCall, List<ChatMessage> messages)
+    {
+        var toolName = functionCall.Name;
+        var action = DeriveAction(toolName);
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine($"  [LLM wants: {toolName}/{action}]");
+        Console.ResetColor();
+
+        // Convert arguments
+        Dictionary<string, object>? args = null;
+        if (functionCall.Arguments != null)
+        {
+            args = new Dictionary<string, object>();
+            foreach (var kvp in functionCall.Arguments)
+            {
+                if (kvp.Value != null)
+                    args[kvp.Key] = kvp.Value;
+            }
+        }
+
+        // Execute through trust layer
+        var result = await _toolExecutor.ExecuteAsync(toolName, action, args);
+
+        if (result.DeniedByPolicy)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine($"  >> TRUST LAYER DENIED: {result.Error}");
+            Console.ResetColor();
+        }
+        else if (result.Success)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"  >> Tool executed (token: {result.TokenId?[..8]}...)");
+            Console.ResetColor();
+        }
+        else
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"  >> Tool failed: {result.Error}");
+            Console.ResetColor();
+        }
+
+        // Feed result back to LLM
+        var resultText = result.Success
+            ? result.Data ?? "Success (no data)"
+            : result.Error ?? "Unknown error";
+
+        messages.Add(new ChatMessage(ChatRole.Tool,
+            [new FunctionResultContent(functionCall.CallId, resultText)]));
+    }
+
+    private static string DeriveAction(string toolName) => toolName switch
+    {
+        "email_sender" => "Send",
+        "code_executor" => "Execute",
+        _ => "Read"
+    };
+
+    private static IList<AITool> CreateToolDefinitions()
+    {
+        return
+        [
+            AIFunctionFactory.Create(
+                (string query) => "placeholder",
+                new AIFunctionFactoryOptions
+                {
+                    Name = "sql_query",
+                    Description = "Execute a SQL query against the employee/business database. " +
+                        "Use this to look up employees, departments, sales data, etc."
+                }),
+            AIFunctionFactory.Create(
+                (string customerId) => "placeholder",
+                new AIFunctionFactoryOptions
+                {
+                    Name = "customer_lookup",
+                    Description = "Look up customer information by ID or name. " +
+                        "Returns customer details, tier, contact history, and open tickets."
+                }),
+            AIFunctionFactory.Create(
+                (string path) => "placeholder",
+                new AIFunctionFactoryOptions
+                {
+                    Name = "file_browser",
+                    Description = "Browse and list files in a directory. " +
+                        "Use this to find reports, data files, and documents."
+                }),
+            AIFunctionFactory.Create(
+                (string to, string subject, string body) => "placeholder",
+                new AIFunctionFactoryOptions
+                {
+                    Name = "email_sender",
+                    Description = "Send an email to a recipient. " +
+                        "Requires to address, subject, and body."
+                }),
+            AIFunctionFactory.Create(
+                (string code, string language) => "placeholder",
+                new AIFunctionFactoryOptions
+                {
+                    Name = "code_executor",
+                    Description = "Execute a code snippet in a sandboxed environment. " +
+                        "Supports Python, JavaScript, and C#."
+                }),
+            AIFunctionFactory.Create(
+                (string secretName) => "placeholder",
+                new AIFunctionFactoryOptions
+                {
+                    Name = "secrets_vault",
+                    Description = "Read a secret or credential from the secure vault. " +
+                        "Use for database passwords, API keys, connection strings."
+                })
+        ];
+    }
+}

--- a/samples/McpTrustDemo/McpTrustDemo.Llm/McpTrustDemo.Llm.csproj
+++ b/samples/McpTrustDemo/McpTrustDemo.Llm/McpTrustDemo.Llm.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework Condition="'$(NETCoreSdkVersion)' >= '10.0.0'">net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>McpTrustDemo.Llm</RootNamespace>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference
+            Include="..\..\..\src\SdJwt.Net.AgentTrust.Core\SdJwt.Net.AgentTrust.Core.csproj" />
+        <ProjectReference
+            Include="..\..\..\src\SdJwt.Net.AgentTrust.Policy\SdJwt.Net.AgentTrust.Policy.csproj" />
+        <ProjectReference
+            Include="..\..\..\src\SdJwt.Net.AgentTrust.Mcp\SdJwt.Net.AgentTrust.Mcp.csproj" />
+        <ProjectReference
+            Include="..\..\..\src\SdJwt.Net.AgentTrust.OpenTelemetry\SdJwt.Net.AgentTrust.OpenTelemetry.csproj" />
+    </ItemGroup>
+</Project>

--- a/samples/McpTrustDemo/McpTrustDemo.Llm/Program.cs
+++ b/samples/McpTrustDemo/McpTrustDemo.Llm/Program.cs
@@ -1,0 +1,98 @@
+using McpTrustDemo.Llm;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using OpenAI;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using SdJwt.Net.AgentTrust.Core;
+using SdJwt.Net.AgentTrust.Mcp;
+using SdJwt.Net.AgentTrust.OpenTelemetry;
+using SdJwt.Net.AgentTrust.Policy;
+using System.Text;
+
+// -------------------------------------------------------------------
+// MCP Trust Demo - Real-World LLM Agent
+// An enterprise AI assistant powered by OpenAI that uses SD-JWT
+// capability tokens to gate every tool invocation.
+// -------------------------------------------------------------------
+
+Console.WriteLine("=============================================================");
+Console.WriteLine("  MCP Tool Marketplace - LLM Agent with Trust Boundaries");
+Console.WriteLine("  Real-world: OpenAI decides tools, SD-JWT gates access");
+Console.WriteLine("=============================================================");
+Console.WriteLine();
+
+var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+{
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.WriteLine("ERROR: Set OPENAI_API_KEY environment variable.");
+    Console.WriteLine("  PowerShell: $env:OPENAI_API_KEY = 'sk-...'");
+    Console.WriteLine("  Bash:       export OPENAI_API_KEY='sk-...'");
+    Console.ResetColor();
+    return;
+}
+
+var serverUrl = Environment.GetEnvironmentVariable("MCP_SERVER_URL") ?? "http://localhost:5100";
+var model = Environment.GetEnvironmentVariable("OPENAI_MODEL") ?? "gpt-4o-mini";
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureLogging(logging =>
+    {
+        logging.SetMinimumLevel(LogLevel.Warning);
+        logging.AddFilter("McpTrustDemo", LogLevel.Information);
+    })
+    .ConfigureServices(services =>
+    {
+        // Shared signing key (must match MCP server)
+        var sharedKeyBytes = Encoding.UTF8.GetBytes("McpTrustDemoSigningKey-32Bytes!!");
+        var signingKey = new SymmetricSecurityKey(sharedKeyBytes);
+        services.AddSingleton(signingKey);
+
+        // Nonce store for replay prevention
+        services.AddSingleton<INonceStore>(new MemoryNonceStore());
+
+        // Policy engine - defines what THIS agent is allowed to do
+        var policyEngine = new DefaultPolicyEngine(
+            new PolicyBuilder()
+                .Allow("agent://enterprise-assistant", "sql_query", "Read")
+                .Allow("agent://enterprise-assistant", "customer_lookup", "Read")
+                .Allow("agent://enterprise-assistant", "file_browser", "Read")
+                .Deny("*", "secrets_vault", "*")
+                .Deny("*", "*", "Delete")
+                .Deny("*", "code_executor", "Execute")
+                .Build());
+        services.AddSingleton<IPolicyEngine>(policyEngine);
+
+        // OpenAI via Microsoft.Extensions.AI
+        services.AddSingleton<IChatClient>(sp =>
+        {
+            var openAiClient = new OpenAIClient(apiKey);
+            return openAiClient.GetChatClient(model).AsIChatClient();
+        });
+
+        // HTTP client for MCP tool server
+        services.AddHttpClient("McpToolServer", client =>
+        {
+            client.BaseAddress = new Uri(serverUrl);
+        });
+
+        // OpenTelemetry
+        services.AddOpenTelemetry()
+            .WithTracing(tracing => tracing
+                .AddAgentTrustInstrumentation()
+                .AddConsoleExporter())
+            .WithMetrics(metrics => metrics
+                .AddAgentTrustInstrumentation()
+                .AddConsoleExporter());
+
+        services.AddSingleton<TrustedToolExecutor>();
+        services.AddSingleton<LlmAgentRunner>();
+    })
+    .Build();
+
+var runner = host.Services.GetRequiredService<LlmAgentRunner>();
+await runner.RunInteractiveAsync();

--- a/samples/McpTrustDemo/McpTrustDemo.Llm/TrustedToolExecutor.cs
+++ b/samples/McpTrustDemo/McpTrustDemo.Llm/TrustedToolExecutor.cs
@@ -1,0 +1,161 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using SdJwt.Net.AgentTrust.Core;
+using SdJwt.Net.AgentTrust.Mcp;
+using SdJwt.Net.AgentTrust.Policy;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace McpTrustDemo.Llm;
+
+/// <summary>
+/// Executes MCP tool calls through the SD-JWT trust layer.
+/// Mints a capability token per call, attaches it, and handles
+/// policy denials and server rejections gracefully.
+/// </summary>
+public class TrustedToolExecutor
+{
+    private readonly McpClientTrustInterceptor _interceptor;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<TrustedToolExecutor> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public TrustedToolExecutor(
+        IPolicyEngine policyEngine,
+        INonceStore nonceStore,
+        SymmetricSecurityKey signingKey,
+        IHttpClientFactory httpClientFactory,
+        ILogger<TrustedToolExecutor> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+
+        _interceptor = new McpClientTrustInterceptor(
+            new CapabilityTokenIssuer(signingKey, SecurityAlgorithms.HmacSha256, nonceStore),
+            policyEngine,
+            new McpClientTrustOptions
+            {
+                AgentId = "agent://enterprise-assistant",
+                ToolAudienceMapping = new Dictionary<string, string>
+                {
+                    ["sql_query"] = "https://mcp-tools.enterprise.local",
+                    ["customer_lookup"] = "https://mcp-tools.enterprise.local",
+                    ["file_browser"] = "https://mcp-tools.enterprise.local",
+                    ["email_sender"] = "https://mcp-tools.enterprise.local",
+                    ["code_executor"] = "https://mcp-tools.enterprise.local",
+                    ["secrets_vault"] = "https://mcp-tools.enterprise.local"
+                },
+                DefaultTokenLifetime = TimeSpan.FromSeconds(60)
+            });
+    }
+
+    /// <summary>
+    /// Attempts to execute a tool call through the trust layer.
+    /// Returns a structured result the LLM can reason about.
+    /// </summary>
+    public async Task<ToolExecutionResult> ExecuteAsync(
+        string toolName,
+        string action,
+        Dictionary<string, object>? arguments = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Tool call: {Tool}/{Action}", toolName, action);
+
+        // Step 1: Policy pre-flight + token minting
+        var mintResult = await _interceptor.BeforeToolCallAsync(
+            new McpToolCall
+            {
+                ToolName = toolName,
+                Action = action,
+                Arguments = arguments,
+                Context = new CapabilityContext
+                {
+                    CorrelationId = Guid.NewGuid().ToString("N"),
+                    WorkflowId = "llm-agent-session"
+                }
+            }, cancellationToken);
+
+        if (!mintResult.IsSuccess)
+        {
+            _logger.LogWarning("Trust layer DENIED: {Tool}/{Action} - {Error}",
+                toolName, action, mintResult.Error);
+
+            return new ToolExecutionResult
+            {
+                Success = false,
+                ToolName = toolName,
+                Action = action,
+                Error = $"ACCESS DENIED by trust policy: {mintResult.Error}",
+                DeniedByPolicy = true
+            };
+        }
+
+        // Step 2: Call the MCP tool server with the capability token
+        var client = _httpClientFactory.CreateClient("McpToolServer");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/tools/{toolName}");
+        request.Headers.Add("Authorization", $"Bearer {mintResult.Token}");
+        request.Content = JsonContent.Create(arguments ?? new Dictionary<string, object>());
+
+        try
+        {
+            var response = await client.SendAsync(request, cancellationToken);
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return new ToolExecutionResult
+                {
+                    Success = true,
+                    ToolName = toolName,
+                    Action = action,
+                    Data = body,
+                    TokenId = mintResult.TokenId
+                };
+            }
+
+            return new ToolExecutionResult
+            {
+                Success = false,
+                ToolName = toolName,
+                Action = action,
+                Error = $"Server rejected (HTTP {(int)response.StatusCode}): {body}",
+                DeniedByPolicy = false
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            return new ToolExecutionResult
+            {
+                Success = false,
+                ToolName = toolName,
+                Action = action,
+                Error = $"Connection error: {ex.Message}. Is the MCP server running on {client.BaseAddress}?"
+            };
+        }
+    }
+}
+
+/// <summary>
+/// Result of a trusted tool execution.
+/// </summary>
+public class ToolExecutionResult
+{
+    public bool Success { get; init; }
+    public string ToolName { get; init; } = string.Empty;
+    public string Action { get; init; } = string.Empty;
+    public string? Data { get; init; }
+    public string? Error { get; init; }
+    public string? TokenId { get; init; }
+    public bool DeniedByPolicy { get; init; }
+
+    public override string ToString()
+    {
+        if (Success)
+            return $"[{ToolName}] Success: {Data}";
+        return $"[{ToolName}] Failed: {Error}";
+    }
+}

--- a/samples/McpTrustDemo/McpTrustDemo.Server/McpTrustDemo.Server.csproj
+++ b/samples/McpTrustDemo/McpTrustDemo.Server/McpTrustDemo.Server.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework Condition="'$(NETCoreSdkVersion)' >= '10.0.0'">net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>McpTrustDemo.Server</RootNamespace>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference
+            Include="..\..\..\src\SdJwt.Net.AgentTrust.Core\SdJwt.Net.AgentTrust.Core.csproj" />
+        <ProjectReference
+            Include="..\..\..\src\SdJwt.Net.AgentTrust.Policy\SdJwt.Net.AgentTrust.Policy.csproj" />
+        <ProjectReference
+            Include="..\..\..\src\SdJwt.Net.AgentTrust.AspNetCore\SdJwt.Net.AgentTrust.AspNetCore.csproj" />
+        <ProjectReference
+            Include="..\..\..\src\SdJwt.Net.AgentTrust.Mcp\SdJwt.Net.AgentTrust.Mcp.csproj" />
+        <ProjectReference
+            Include="..\..\..\src\SdJwt.Net.AgentTrust.OpenTelemetry\SdJwt.Net.AgentTrust.OpenTelemetry.csproj" />
+    </ItemGroup>
+</Project>

--- a/samples/McpTrustDemo/McpTrustDemo.Server/Program.cs
+++ b/samples/McpTrustDemo/McpTrustDemo.Server/Program.cs
@@ -1,0 +1,311 @@
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using SdJwt.Net.AgentTrust.AspNetCore;
+using SdJwt.Net.AgentTrust.Core;
+using SdJwt.Net.AgentTrust.Mcp;
+using SdJwt.Net.AgentTrust.OpenTelemetry;
+using SdJwt.Net.AgentTrust.Policy;
+using System.Text;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// -------------------------------------------------------------------
+// Shared signing key (in production, resolve from JWKS endpoint)
+// -------------------------------------------------------------------
+var sharedKeyBytes = Encoding.UTF8.GetBytes(
+    builder.Configuration["AgentTrust:SigningKey"] ?? "McpTrustDemoSigningKey-32Bytes!!");
+var signingKey = new SymmetricSecurityKey(sharedKeyBytes);
+
+// -------------------------------------------------------------------
+// Policy engine: define what agents can do with each tool
+// -------------------------------------------------------------------
+var policyRules = new PolicyBuilder()
+    // Data Analyst can query and summarize, but not modify
+    .Allow("agent://data-analyst", "sql_query", "Read", c =>
+    {
+        c.MaxLifetime(TimeSpan.FromSeconds(120));
+        c.Limits(new CapabilityLimits { MaxResults = 1000 });
+    })
+    .Allow("agent://data-analyst", "file_browser", "Read")
+    // Customer Support can read customer data and send emails
+    .Allow("agent://customer-support", "customer_lookup", "Read")
+    .Allow("agent://customer-support", "email_sender", "Send", c =>
+    {
+        c.MaxLifetime(TimeSpan.FromSeconds(30));
+        c.Limits(new CapabilityLimits { MaxInvocations = 5 });
+    })
+    // Code Assistant can read files and execute code in sandbox
+    .Allow("agent://code-assistant", "file_browser", "Read")
+    .Allow("agent://code-assistant", "code_executor", "Execute", c =>
+    {
+        c.MaxLifetime(TimeSpan.FromSeconds(60));
+        c.Limits(new CapabilityLimits { MaxPayloadBytes = 10240 });
+    })
+    // Orchestrator can delegate sql_query:Read to worker agents
+    .Allow("agent://orchestrator", "sql_query", "Read")
+    // Enterprise LLM assistant: read-only access to safe tools
+    .Allow("agent://enterprise-assistant", "sql_query", "Read")
+    .Allow("agent://enterprise-assistant", "customer_lookup", "Read")
+    .Allow("agent://enterprise-assistant", "file_browser", "Read")
+    // Global deny: no agent can delete anything
+    .Deny("*", "*", "Delete")
+    // Global deny: no agent can access secrets
+    .Deny("*", "secrets_vault", "*")
+    .Build();
+
+var policyEngine = new DefaultPolicyEngine(policyRules);
+
+// -------------------------------------------------------------------
+// Register Agent Trust services
+// -------------------------------------------------------------------
+var nonceStore = new MemoryNonceStore();
+builder.Services.AddSingleton<INonceStore>(nonceStore);
+builder.Services.AddSingleton<IPolicyEngine>(policyEngine);
+builder.Services.AddSingleton(new CapabilityTokenVerifier(nonceStore));
+
+builder.Services.AddMcpServerTrust(options =>
+{
+    options.Audience = "https://mcp-tools.enterprise.local";
+    options.TrustedIssuers = new Dictionary<string, SecurityKey>
+    {
+        ["agent://data-analyst"] = signingKey,
+        ["agent://customer-support"] = signingKey,
+        ["agent://code-assistant"] = signingKey,
+        ["agent://orchestrator"] = signingKey,
+        ["agent://enterprise-assistant"] = signingKey
+    };
+});
+
+var verificationOptions = new AgentTrustVerificationOptions
+{
+    Audience = "https://mcp-tools.enterprise.local",
+    TrustedIssuers = new Dictionary<string, SecurityKey>
+    {
+        ["agent://data-analyst"] = signingKey,
+        ["agent://customer-support"] = signingKey,
+        ["agent://code-assistant"] = signingKey,
+        ["agent://orchestrator"] = signingKey,
+        ["agent://enterprise-assistant"] = signingKey
+    },
+    ExcludedPaths = ["/health", "/tools/manifest"],
+    EmitReceipts = true
+};
+builder.Services.AddSingleton(Options.Create(verificationOptions));
+
+builder.Services.AddSingleton<IReceiptWriter>(new TelemetryReceiptWriter(new LoggingReceiptWriter()));
+
+// -------------------------------------------------------------------
+// OpenTelemetry observability
+// -------------------------------------------------------------------
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddAgentTrustInstrumentation()
+        .AddConsoleExporter())
+    .WithMetrics(metrics => metrics
+        .AddAgentTrustInstrumentation()
+        .AddConsoleExporter());
+
+var app = builder.Build();
+
+// -------------------------------------------------------------------
+// Middleware pipeline
+// Note: Per-endpoint McpServerTrustGuard is used instead of global
+// middleware to avoid double nonce consumption (replay false positives).
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+// Health check (excluded from trust verification)
+// -------------------------------------------------------------------
+app.MapGet("/health", () => Results.Ok(new { status = "healthy", timestamp = DateTimeOffset.UtcNow }));
+
+// -------------------------------------------------------------------
+// Tool manifest endpoint (excluded from trust verification)
+// -------------------------------------------------------------------
+app.MapGet("/tools/manifest", () => Results.Ok(new McpToolTrustManifest[]
+{
+    new()
+    {
+        Name = "sql_query",
+        Audience = "https://mcp-tools.enterprise.local",
+        Actions = new[] { "Read" },
+        RequiresCapabilityToken = true,
+        MaxTokenLifetime = TimeSpan.FromSeconds(120)
+    },
+    new()
+    {
+        Name = "file_browser",
+        Audience = "https://mcp-tools.enterprise.local",
+        Actions = new[] { "Read", "List" },
+        RequiresCapabilityToken = true,
+        MaxTokenLifetime = TimeSpan.FromSeconds(60)
+    },
+    new()
+    {
+        Name = "customer_lookup",
+        Audience = "https://mcp-tools.enterprise.local",
+        Actions = new[] { "Read" },
+        RequiresCapabilityToken = true
+    },
+    new()
+    {
+        Name = "email_sender",
+        Audience = "https://mcp-tools.enterprise.local",
+        Actions = new[] { "Send" },
+        RequiresCapabilityToken = true,
+        MaxTokenLifetime = TimeSpan.FromSeconds(30)
+    },
+    new()
+    {
+        Name = "code_executor",
+        Audience = "https://mcp-tools.enterprise.local",
+        Actions = new[] { "Execute" },
+        RequiresCapabilityToken = true,
+        MaxTokenLifetime = TimeSpan.FromSeconds(60)
+    },
+    new()
+    {
+        Name = "secrets_vault",
+        Audience = "https://mcp-tools.enterprise.local",
+        Actions = new[] { "Read", "Write" },
+        RequiresCapabilityToken = true
+    }
+}));
+
+// -------------------------------------------------------------------
+// MCP Tool Endpoints (protected by capability tokens)
+// -------------------------------------------------------------------
+app.MapPost("/tools/sql_query", async (HttpContext context, McpServerTrustGuard guard) =>
+{
+    var token = context.Request.Headers["Authorization"].ToString().Replace("Bearer ", "");
+    var result = await guard.VerifyToolCallAsync("sql_query", token);
+
+    if (!result.IsValid)
+    {
+        return Results.Json(new { error = result.Error, code = result.ErrorCode }, statusCode: 403);
+    }
+
+    // Simulated SQL query execution
+    return Results.Ok(new
+    {
+        tool = "sql_query",
+        action = result.Capability?.Action,
+        result = new[]
+        {
+            new { id = 1, name = "Alice Johnson", email = "alice@example.com", department = "Engineering" },
+            new { id = 2, name = "Bob Smith", email = "bob@example.com", department = "Sales" },
+            new { id = 3, name = "Carol Williams", email = "carol@example.com", department = "Marketing" }
+        },
+        metadata = new
+        {
+            rowsReturned = 3,
+            executionTimeMs = 42,
+            correlationId = result.Context?.CorrelationId
+        }
+    });
+});
+
+app.MapPost("/tools/file_browser", async (HttpContext context, McpServerTrustGuard guard) =>
+{
+    var token = context.Request.Headers["Authorization"].ToString().Replace("Bearer ", "");
+    var result = await guard.VerifyToolCallAsync("file_browser", token);
+
+    if (!result.IsValid)
+    {
+        return Results.Json(new { error = result.Error, code = result.ErrorCode }, statusCode: 403);
+    }
+
+    return Results.Ok(new
+    {
+        tool = "file_browser",
+        action = result.Capability?.Action,
+        files = new[]
+        {
+            new { path = "/reports/q4-summary.csv", size = 24576, modified = "2026-04-28T10:30:00Z" },
+            new { path = "/reports/annual-review.pdf", size = 1048576, modified = "2026-04-15T14:00:00Z" },
+            new { path = "/data/customers.json", size = 51200, modified = "2026-04-30T08:00:00Z" }
+        },
+        correlationId = result.Context?.CorrelationId
+    });
+});
+
+app.MapPost("/tools/customer_lookup", async (HttpContext context, McpServerTrustGuard guard) =>
+{
+    var token = context.Request.Headers["Authorization"].ToString().Replace("Bearer ", "");
+    var result = await guard.VerifyToolCallAsync("customer_lookup", token);
+
+    if (!result.IsValid)
+    {
+        return Results.Json(new { error = result.Error, code = result.ErrorCode }, statusCode: 403);
+    }
+
+    return Results.Ok(new
+    {
+        tool = "customer_lookup",
+        customer = new
+        {
+            id = "cust-9281",
+            name = "Acme Corporation",
+            tier = "Enterprise",
+            lastContact = "2026-04-25T09:15:00Z",
+            openTickets = 2
+        },
+        correlationId = result.Context?.CorrelationId
+    });
+});
+
+app.MapPost("/tools/email_sender", async (HttpContext context, McpServerTrustGuard guard) =>
+{
+    var token = context.Request.Headers["Authorization"].ToString().Replace("Bearer ", "");
+    var result = await guard.VerifyToolCallAsync("email_sender", token);
+
+    if (!result.IsValid)
+    {
+        return Results.Json(new { error = result.Error, code = result.ErrorCode }, statusCode: 403);
+    }
+
+    return Results.Ok(new
+    {
+        tool = "email_sender",
+        status = "sent",
+        messageId = Guid.NewGuid().ToString("N"),
+        correlationId = result.Context?.CorrelationId
+    });
+});
+
+app.MapPost("/tools/code_executor", async (HttpContext context, McpServerTrustGuard guard) =>
+{
+    var token = context.Request.Headers["Authorization"].ToString().Replace("Bearer ", "");
+    var result = await guard.VerifyToolCallAsync("code_executor", token);
+
+    if (!result.IsValid)
+    {
+        return Results.Json(new { error = result.Error, code = result.ErrorCode }, statusCode: 403);
+    }
+
+    return Results.Ok(new
+    {
+        tool = "code_executor",
+        action = result.Capability?.Action,
+        output = "Hello, World!\nExecution completed in 120ms.",
+        exitCode = 0,
+        correlationId = result.Context?.CorrelationId
+    });
+});
+
+app.MapPost("/tools/secrets_vault", async (HttpContext context, McpServerTrustGuard guard) =>
+{
+    var token = context.Request.Headers["Authorization"].ToString().Replace("Bearer ", "");
+    var result = await guard.VerifyToolCallAsync("secrets_vault", token);
+
+    if (!result.IsValid)
+    {
+        return Results.Json(new { error = result.Error, code = result.ErrorCode }, statusCode: 403);
+    }
+
+    // This should never be reached because policy denies all agents
+    return Results.Ok(new { tool = "secrets_vault", secret = "SHOULD_NOT_BE_VISIBLE" });
+});
+
+app.Run();

--- a/samples/McpTrustDemo/McpTrustDemo.Server/Properties/launchSettings.json
+++ b/samples/McpTrustDemo/McpTrustDemo.Server/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "McpTrustDemo.Server": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5100",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/McpTrustDemo/McpTrustDemo.Server/appsettings.json
+++ b/samples/McpTrustDemo/McpTrustDemo.Server/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "SdJwt.Net.AgentTrust": "Debug"
+    }
+  },
+  "AgentTrust": {
+    "SigningKey": "McpTrustDemoSigningKey-32Bytes!!"
+  },
+  "Urls": "http://localhost:5100"
+}

--- a/samples/McpTrustDemo/README.md
+++ b/samples/McpTrustDemo/README.md
@@ -1,0 +1,435 @@
+# MCP Tool Marketplace with Agent Trust
+
+A production-realistic demo showing how AI agents access MCP tool servers with **cryptographically-enforced, least-privilege capability tokens** using SD-JWT.
+
+## Problem Statement
+
+Organizations deploying multiple AI agents (data analysts, customer support bots, code assistants) face a critical security gap: **MCP (Model Context Protocol) has no built-in authorization model.** Any agent that can reach a tool server can invoke any tool without limits.
+
+This demo solves that problem by adding a trust layer:
+
+- Each agent receives **scoped, time-limited capability tokens** (SD-JWT format)
+- The tool server **verifies tokens per tool call** and enforces policy
+- **Replay attacks** are detected and blocked
+- **Cross-agent boundary violations** are denied at both client and server
+- **Full audit trail** with OpenTelemetry observability
+
+## Architecture
+
+```
++-----------------------------------------------------------+
+|  AI Agents (MCP Clients)                                  |
+|                                                           |
+|  +------------------+  +------------------+               |
+|  | Data Analyst     |  | Customer Support |  ...          |
+|  | sql_query: Read  |  | customer: Read   |               |
+|  | file_browser: Rd |  | email: Send      |               |
+|  +--------+---------+  +--------+---------+               |
+|           |                      |                        |
+|           v                      v                        |
+|  +----------------------------------------------------+  |
+|  |  McpClientTrustInterceptor                         |  |
+|  |  - Evaluates policy (pre-flight)                   |  |
+|  |  - Mints scoped SD-JWT capability token            |  |
+|  |  - Attaches token to outbound request              |  |
+|  +----------------------------------------------------+  |
++-----------------------------------------------------------+
+            |
+            |  HTTP + Authorization: SdJwt <token>
+            v
++-----------------------------------------------------------+
+|  MCP Tool Server (ASP.NET Core)                           |
+|                                                           |
+|  +----------------------------------------------------+  |
+|  |  AgentTrustVerificationMiddleware                  |  |
+|  |  - Extracts token from request                     |  |
+|  |  - Verifies signature, expiry, audience            |  |
+|  |  - Checks replay (nonce store)                     |  |
+|  +----------------------------------------------------+  |
+|                         |                                 |
+|                         v                                 |
+|  +----------------------------------------------------+  |
+|  |  McpServerTrustGuard                               |  |
+|  |  - Validates tool-name matches token cap.tool      |  |
+|  |  - Evaluates server-side policy                    |  |
+|  |  - Emits audit receipt                             |  |
+|  +----------------------------------------------------+  |
+|                         |                                 |
+|                         v                                 |
+|  +----------+  +------------+  +----------+  +---------+ |
+|  | sql_query|  |file_browser|  |email_send|  |code_exec| |
+|  +----------+  +------------+  +----------+  +---------+ |
+|                                                           |
+|  +----------------------------------------------------+  |
+|  |  OpenTelemetry: Traces + Metrics                   |  |
+|  |  agent_trust.tokens.minted/verified/rejected       |  |
+|  |  agent_trust.policy.evaluations/denials            |  |
+|  +----------------------------------------------------+  |
++-----------------------------------------------------------+
+```
+
+## Demo Scenarios
+
+| #   | Scenario                  | Agent                  | Tool                    | Expected Result     |
+| --- | ------------------------- | ---------------------- | ----------------------- | ------------------- |
+| 1   | Authorized access         | Data Analyst           | sql_query (Read)        | SUCCESS             |
+| 2   | Authorized access         | Customer Support       | customer_lookup (Read)  | SUCCESS             |
+| 3   | Authorized access         | Code Assistant         | code_executor (Execute) | SUCCESS             |
+| 4   | Cross-boundary denial     | Data Analyst           | email_sender (Send)     | DENIED              |
+| 5   | Action denial             | Code Assistant         | file_browser (Delete)   | DENIED              |
+| 6   | Sensitive resource denial | Data Analyst           | secrets_vault (Read)    | DENIED              |
+| 7   | Replay attack prevention  | Data Analyst           | sql_query (reuse token) | BLOCKED             |
+| 8   | Agent-to-agent delegation | Orchestrator -> Worker | sql_query (Read)        | SUCCESS (delegated) |
+
+## Prerequisites
+
+- .NET 9.0 SDK or later
+- No external dependencies required (runs fully in-process with simulated tools)
+
+## Running the Demo
+
+### Option 1: Two terminals (recommended for visibility)
+
+**Terminal 1 - Start the MCP Tool Server:**
+
+```pwsh
+cd samples/McpTrustDemo/McpTrustDemo.Server
+dotnet run
+```
+
+The server starts on `http://localhost:5100`.
+
+**Terminal 2 - Run the Client:**
+
+```pwsh
+cd samples/McpTrustDemo/McpTrustDemo.Client
+dotnet run
+```
+
+### Option 2: Single terminal with background server
+
+```pwsh
+cd samples/McpTrustDemo
+
+# Start server in background
+Start-Job { dotnet run --project McpTrustDemo.Server }
+
+# Wait for server to be ready
+Start-Sleep -Seconds 3
+
+# Run client
+dotnet run --project McpTrustDemo.Client
+
+# Clean up
+Get-Job | Stop-Job | Remove-Job
+```
+
+### Custom server URL
+
+```pwsh
+dotnet run --project McpTrustDemo.Client -- http://localhost:5100
+```
+
+## Policy Configuration
+
+The demo uses a declarative policy engine with these rules:
+
+```csharp
+// Data Analyst: read-only access to SQL and files
+Allow("agent://data-analyst", "sql_query", "Read")
+Allow("agent://data-analyst", "file_browser", "Read")
+
+// Customer Support: customer data + limited email
+Allow("agent://customer-support", "customer_lookup", "Read")
+Allow("agent://customer-support", "email_sender", "Send")
+
+// Code Assistant: file reading + code execution
+Allow("agent://code-assistant", "file_browser", "Read")
+Allow("agent://code-assistant", "code_executor", "Execute")
+
+// Global denials
+Deny("*", "*", "Delete")           // No agent can delete anything
+Deny("*", "secrets_vault", "*")    // No agent can access secrets
+```
+
+## Integration with Microsoft Agent Framework
+
+This demo is designed to integrate with the Microsoft Agent Framework (MAF) / Semantic Kernel agent patterns. The `McpClientTrustInterceptor` can be wired into any agent framework's tool-calling pipeline:
+
+### Semantic Kernel Integration
+
+```csharp
+// Register as a filter in Semantic Kernel's function invocation pipeline
+public class AgentTrustFilter : IFunctionInvocationFilter
+{
+    private readonly McpClientTrustInterceptor _interceptor;
+
+    public async Task OnFunctionInvocationAsync(
+        FunctionInvocationContext context,
+        Func<FunctionInvocationContext, Task> next)
+    {
+        // Mint capability token before calling the MCP tool
+        var result = await _interceptor.BeforeToolCallAsync(new McpToolCall
+        {
+            ToolName = context.Function.Name,
+            Action = DeriveAction(context),
+            Context = new CapabilityContext
+            {
+                CorrelationId = context.ChatHistory?.GetCorrelationId(),
+                WorkflowId = context.Function.PluginName
+            }
+        });
+
+        if (!result.IsSuccess)
+        {
+            throw new UnauthorizedAccessException(
+                $"Agent trust denied: {result.Error}");
+        }
+
+        // Attach token to outbound call metadata
+        context.Arguments["_agent_trust_token"] = result.Token;
+        await next(context);
+    }
+}
+```
+
+### Microsoft Agent Framework (MAF) Integration
+
+The `SdJwt.Net.AgentTrust.Maf` package provides first-class middleware:
+
+```csharp
+// In agent builder configuration
+agentBuilder.Use<AgentTrustMiddleware>(options =>
+{
+    options.AgentId = "agent://my-agent";
+    options.ToolAudienceMapping = new Dictionary<string, string>
+    {
+        ["sql_query"] = "https://mcp-tools.enterprise.local"
+    };
+});
+```
+
+### Azure AI Agent Service
+
+When deploying to Azure AI Agent Service, configure the trust interceptor as middleware in the agent's tool pipeline. The signing keys can be stored in Azure Key Vault and resolved via `IKeyCustodyProvider`.
+
+## Deployment Guide
+
+### Local Development
+
+The demo runs out of the box with shared symmetric keys. For production:
+
+1. Replace symmetric keys with asymmetric (EC P-256 or RSA) key pairs
+2. Publish JWKS endpoints for each agent's public key
+3. Configure the server's `TrustedIssuers` to resolve keys from JWKS URIs
+
+### Docker Deployment
+
+```dockerfile
+# Server
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
+COPY publish/ /app
+WORKDIR /app
+EXPOSE 5100
+ENTRYPOINT ["dotnet", "McpTrustDemo.Server.dll"]
+```
+
+```pwsh
+# Build and run
+dotnet publish McpTrustDemo.Server -c Release -o publish
+docker build -t mcp-trust-server .
+docker run -p 5100:5100 mcp-trust-server
+```
+
+### Azure Container Apps
+
+```pwsh
+# Deploy with Azure Developer CLI
+azd init --template mcp-trust-demo
+azd up
+```
+
+Or manually:
+
+```pwsh
+az containerapp up \
+  --name mcp-trust-server \
+  --resource-group rg-mcp-trust \
+  --image mcp-trust-server:latest \
+  --target-port 5100 \
+  --ingress external
+```
+
+### Production Considerations
+
+| Concern           | Solution                                                         |
+| ----------------- | ---------------------------------------------------------------- |
+| Key management    | Azure Key Vault + `IKeyCustodyProvider`                          |
+| Key rotation      | JWKS endpoint with key rollover                                  |
+| Replay prevention | Distributed nonce store (Redis)                                  |
+| Policy management | OPA (Open Policy Agent) via `SdJwt.Net.AgentTrust.Policy.Opa`    |
+| Observability     | OpenTelemetry -> Azure Monitor / Prometheus + Grafana            |
+| Agent identity    | Workload Identity (SPIFFE/Entra) via `IWorkloadIdentityProvider` |
+| Multi-tenant      | `CapabilityContext.TenantId` with tenant-scoped policies         |
+
+## Security Model
+
+### What capability tokens prevent
+
+1. **Privilege escalation** - Agents cannot access tools outside their policy scope
+2. **Replay attacks** - Each token is single-use (nonce store)
+3. **Token theft** - Short-lived tokens (30-120s) with audience binding
+4. **Lateral movement** - Tool-name validation ensures tokens cannot be used across tools
+5. **Unauthorized delegation** - Depth-limited chains with cryptographic hop verification
+
+### Trust boundaries enforced
+
+```
+Human -> Orchestrator Agent -> Worker Agent -> MCP Tool Server
+  |          |                    |               |
+  | grants   | delegates         | presents      | verifies
+  | policy   | scoped token      | token         | signature + policy
+  |          | (depth=0)         | (depth=1)     | + replay + audience
+```
+
+## Packages Used
+
+| Package                              | Role in Demo                        |
+| ------------------------------------ | ----------------------------------- |
+| `SdJwt.Net.AgentTrust.Core`          | Token minting and verification      |
+| `SdJwt.Net.AgentTrust.Policy`        | Rule-based authorization engine     |
+| `SdJwt.Net.AgentTrust.Mcp`           | Client interceptor + server guard   |
+| `SdJwt.Net.AgentTrust.AspNetCore`    | HTTP middleware for the tool server |
+| `SdJwt.Net.AgentTrust.A2A`           | Agent-to-agent delegation           |
+| `SdJwt.Net.AgentTrust.OpenTelemetry` | Metrics and tracing                 |
+
+## Expected Output
+
+```
+=============================================================
+  MCP Tool Marketplace with Agent Trust - Client Demo
+=============================================================
+
+--- 1. Authorized Access - Data Analyst queries SQL ---
+  Agent: Data Analyst Agent (agent://data-analyst)
+  Tool: sql_query, Action: Read
+  SUCCESS (HTTP 200)
+  Response: { "tool": "sql_query", "result": [...] }
+
+--- 4. Cross-Boundary Denial - Data Analyst tries email_sender ---
+  Agent: Data Analyst Agent (agent://data-analyst)
+  Tool: email_sender, Action: Send
+  DENIED (client-side): Policy denied.
+  [EXPECTED] Policy correctly blocked unauthorized access.
+
+--- 7. Replay Attack Prevention ---
+  Token minted: abc123...
+  First use: HTTP 200 (authorized)
+  Replay attempt: HTTP 403 (rejected - replay detected)
+  [EXPECTED] Server detected token reuse and blocked the replay attack.
+
+--- 8. Agent-to-Agent Delegation (A2A) ---
+  Delegation token minted: def456...
+  Delegated call result: HTTP 200
+  [SUCCESS] Delegated token accepted by server.
+=============================================================
+  Demo complete. All scenarios executed.
+=============================================================
+```
+
+## LLM Demo (Real-World End-to-End)
+
+The `McpTrustDemo.Llm` project connects a **real OpenAI LLM** to the same MCP tool server. The LLM autonomously decides which tools to call; the SD-JWT trust layer gates every invocation.
+
+### What it demonstrates
+
+| Prompt                          | LLM Decision            | Trust Layer                |
+| ------------------------------- | ----------------------- | -------------------------- |
+| "Show me Engineering employees" | Calls `sql_query`       | **ALLOWED** - token minted |
+| "Look up Acme Corporation"      | Calls `customer_lookup` | **ALLOWED** - token minted |
+| "List files in /reports"        | Calls `file_browser`    | **ALLOWED** - token minted |
+| "Send email to bob@..."         | Calls `email_sender`    | **DENIED** - policy blocks |
+| "Run this Python code"          | Calls `code_executor`   | **DENIED** - policy blocks |
+| "Get database password"         | Calls `secrets_vault`   | **DENIED** - policy blocks |
+
+The LLM receives the denial reason and explains to the user why it can't perform the action.
+
+### Prerequisites
+
+- .NET 9.0 SDK or later
+- An OpenAI API key with available quota (`gpt-4o-mini` by default)
+
+### Running the LLM Demo
+
+**Terminal 1 - Start the MCP Tool Server:**
+
+```pwsh
+dotnet run --project samples/McpTrustDemo/McpTrustDemo.Server
+```
+
+**Terminal 2 - Run the LLM Agent:**
+
+```pwsh
+$env:OPENAI_API_KEY = "sk-..."
+dotnet run --project samples/McpTrustDemo/McpTrustDemo.Llm
+```
+
+### Environment Variables
+
+| Variable         | Default                 | Description                       |
+| ---------------- | ----------------------- | --------------------------------- |
+| `OPENAI_API_KEY` | (required)              | Your OpenAI API key               |
+| `OPENAI_MODEL`   | `gpt-4o-mini`           | Model to use for function calling |
+| `MCP_SERVER_URL` | `http://localhost:5100` | MCP tool server URL               |
+
+### How it works
+
+```
+User Prompt
+    │
+    ▼
+┌─────────────────────────────────┐
+│  OpenAI (gpt-4o-mini)           │
+│  System prompt: available tools │
+│  → Decides: "call sql_query"    │
+└──────────────┬──────────────────┘
+               │ function_call
+               ▼
+┌─────────────────────────────────┐
+│  TrustedToolExecutor            │
+│  1. Policy pre-flight check     │
+│  2. Mint SD-JWT capability token│
+│  3. HTTP call with SdJwt header │
+│  4. Return result OR denial     │
+└──────────────┬──────────────────┘
+               │
+               ▼
+┌─────────────────────────────────┐
+│  MCP Tool Server                │
+│  Verify token → Execute → Reply │
+└─────────────────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────┐
+│  OpenAI (continuation)          │
+│  Formats result for user        │
+│  OR explains why denied         │
+└─────────────────────────────────┘
+```
+
+### Interactive mode
+
+After the 6 demo prompts run automatically, the LLM demo enters interactive mode where you can ask any question. Try prompts that push boundaries:
+
+```
+You: Delete all the files in /reports
+You: What's the database connection string?
+You: Look up customer Acme and email them a summary
+```
+
+## Further Reading
+
+- [SD-JWT RFC 9901](https://www.rfc-editor.org/rfc/rfc9901)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Agent Trust Concepts](../../docs/concepts/)
+- [Microsoft Agent Framework](https://learn.microsoft.com/azure/ai-services/agents/)

--- a/src/SdJwt.Net.AgentTrust.AspNetCore/AgentTrustVerificationOptions.cs
+++ b/src/SdJwt.Net.AgentTrust.AspNetCore/AgentTrustVerificationOptions.cs
@@ -30,9 +30,9 @@ public record AgentTrustVerificationOptions
     public string TokenHeaderName { get; init; } = "Authorization";
 
     /// <summary>
-    /// Token header prefix.
+    /// Token header prefix (RFC 6750 Bearer scheme recommended for SD-JWT tokens).
     /// </summary>
-    public string TokenHeaderPrefix { get; init; } = "SdJwt";
+    public string TokenHeaderPrefix { get; init; } = "Bearer";
 
     /// <summary>
     /// Excluded path patterns.

--- a/src/SdJwt.Net.AgentTrust.Core/CapabilityTokenIssuer.cs
+++ b/src/SdJwt.Net.AgentTrust.Core/CapabilityTokenIssuer.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.IdentityModel.Tokens;
+using SdJwt.Net;
 using SdJwt.Net.Issuer;
 using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
@@ -98,7 +99,7 @@ public class CapabilityTokenIssuer
         activity?.SetTag("agent_trust.tool", options.Capability.Tool);
         activity?.SetTag("agent_trust.action", options.Capability.Action);
 
-        var issuance = _sdIssuer.Issue(claims, new SdIssuanceOptions()).Issuance;
+        var issuance = _sdIssuer.Issue(claims, new SdIssuanceOptions(), tokenType: SdJwtConstants.SdJwtVcTypeName).Issuance;
         _logger.LogDebug("Minted capability token {TokenId} for {Audience}", tokenId, options.Audience);
 
         return new CapabilityTokenResult

--- a/src/SdJwt.Net.AgentTrust.Maf/AgentTrustMiddlewareOptions.cs
+++ b/src/SdJwt.Net.AgentTrust.Maf/AgentTrustMiddlewareOptions.cs
@@ -33,9 +33,9 @@ public record AgentTrustMiddlewareOptions
     public string TokenHeaderName { get; init; } = "Authorization";
 
     /// <summary>
-    /// Header prefix.
+    /// Header prefix (RFC 6750 Bearer scheme recommended for SD-JWT tokens).
     /// </summary>
-    public string TokenHeaderPrefix { get; init; } = "SdJwt";
+    public string TokenHeaderPrefix { get; init; } = "Bearer";
 
     /// <summary>
     /// Whether to emit receipts.

--- a/tests/SdJwt.Net.AgentTrust.AspNetCore.Tests/AgentTrustVerificationMiddlewareTests.cs
+++ b/tests/SdJwt.Net.AgentTrust.AspNetCore.Tests/AgentTrustVerificationMiddlewareTests.cs
@@ -80,7 +80,7 @@ public class AgentTrustVerificationMiddlewareTests
 
         var context = new DefaultHttpContext();
         context.Request.Path = "/api/weather";
-        context.Request.Headers.Authorization = $"SdJwt {token}";
+        context.Request.Headers.Authorization = $"Bearer {token}";
 
         var middleware = new AgentTrustVerificationMiddleware(
             _ => Task.CompletedTask,
@@ -132,7 +132,7 @@ public class AgentTrustVerificationMiddlewareTests
         var middleware = CreateMiddleware(verifier);
 
         var context = new DefaultHttpContext();
-        context.Request.Headers.Authorization = $"Bearer {token}";
+        context.Request.Headers.Authorization = $"Basic {token}";
 
         await middleware.InvokeAsync(context);
 
@@ -147,7 +147,7 @@ public class AgentTrustVerificationMiddlewareTests
         var middleware = CreateMiddleware(verifier);
 
         var context = new DefaultHttpContext();
-        context.Request.Headers.Authorization = "SdJwt not.a.valid.token";
+        context.Request.Headers.Authorization = "Bearer not.a.valid.token";
 
         await middleware.InvokeAsync(context);
 

--- a/tests/SdJwt.Net.AgentTrust.Maf.Tests/McpTrustAdapterTests.cs
+++ b/tests/SdJwt.Net.AgentTrust.Maf.Tests/McpTrustAdapterTests.cs
@@ -137,7 +137,7 @@ public class AgentTrustMiddlewareTests
 
         captured.Should().NotBeNull();
         captured!.Metadata.Should().ContainKey("Authorization");
-        captured.Metadata["Authorization"].ToString().Should().StartWith("SdJwt ");
+        captured.Metadata["Authorization"].ToString().Should().StartWith("Bearer ");
     }
 
     [Fact]


### PR DESCRIPTION
Add a new MCP Trust Demo sample and comprehensive demo docs, plus terminology explaining "minting" vs "issuing". Update example docs and sample code to use Bearer Authorization headers. Overhaul CI: publish-nuget.yml and reusable-build-pack.yml now install multiple .NET SDKs (8/9/10), reorganize and harden package validation/publish steps, improve dry-run behavior, and add enhanced semver/size checks. Minor workspace tweaks (VSCode: enable dotnet run) and small API/options and test updates to support the demo and workflow changes.