### PR TITLE
fix: propagate certificate chain validation result in VerifyDocument

### DIFF
--- a/src/SdJwt.Net.Mdoc/Verifier/MdocVerifier.cs
+++ b/src/SdJwt.Net.Mdoc/Verifier/MdocVerifier.cs
@@ -87,6 +87,14 @@ public class MdocVerifier
         }
 
         result.IssuerSignatureValid = true;
+        result.CertificateChainValid = issuerAuthResult.CertificateChainValid;
+
+        if (!result.CertificateChainValid)
+        {
+            result.Errors.AddRange(issuerAuthResult.Errors);
+            return result;
+        }
+
         result.MobileSecurityObject = issuerAuthResult.MobileSecurityObject;
 
         // Verify MSO docType matches Document docType

--- a/tests/SdJwt.Net.Mdoc.Tests/Verifier/MdocVerifierTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Verifier/MdocVerifierTests.cs
@@ -282,4 +282,122 @@ public class MdocVerifierTests : TestBase
         options.TrustedIssuers.Should().NotBeNull();
         options.TrustedIssuers.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task VerifyDocument_WithTrustedIssuerCert_CertificateChainValidIsTrue()
+    {
+        // Arrange
+        var certRequest = new CertificateRequest(
+            "CN=Test Issuer", IssuerSigningKey, HashAlgorithmName.SHA256);
+        using var cert = certRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        var certBytes = cert.RawData;
+
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithIssuerCertificate(certBytes)
+            .WithDeviceKey(CoseKey.FromECDsa(DeviceKey))
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        var options = new MdocVerificationOptions
+        {
+            VerifyDeviceSignature = false,
+            VerifyCertificateChain = true,
+            VerifyValidity = false,
+            TrustedIssuers = { certBytes }
+        };
+        var verifier = new MdocVerifier(options);
+
+        // Act
+        var result = verifier.VerifyDocument(document);
+
+        // Assert
+        result.CertificateChainValid.Should().BeTrue();
+        result.IssuerSignatureValid.Should().BeTrue();
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task VerifyDocument_WithUntrustedIssuerCert_CertificateChainValidIsFalseAndIsValidIsFalse()
+    {
+        // Arrange - issue with a cert that is NOT in TrustedIssuers
+        var issuerCertRequest = new CertificateRequest(
+            "CN=Test Issuer", IssuerSigningKey, HashAlgorithmName.SHA256);
+        using var issuerCert = issuerCertRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        var issuerCertBytes = issuerCert.RawData;
+
+        // A different cert that the verifier trusts — not the issuer's cert
+        using var otherKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var otherCertRequest = new CertificateRequest(
+            "CN=Other CA", otherKey, HashAlgorithmName.SHA256);
+        using var otherCert = otherCertRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        var otherCertBytes = otherCert.RawData;
+
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithIssuerCertificate(issuerCertBytes)
+            .WithDeviceKey(CoseKey.FromECDsa(DeviceKey))
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        var options = new MdocVerificationOptions
+        {
+            VerifyDeviceSignature = false,
+            VerifyCertificateChain = true,
+            VerifyValidity = false,
+            TrustedIssuers = { otherCertBytes }  // trusts a different cert, not the issuer's
+        };
+        var verifier = new MdocVerifier(options);
+
+        // Act
+        var result = verifier.VerifyDocument(document);
+
+        // Assert
+        result.IssuerSignatureValid.Should().BeTrue();          // signature itself was valid
+        result.CertificateChainValid.Should().BeFalse();        // but the cert wasn't trusted
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("certificate chain"));
+    }
+
+    [Fact]
+    public async Task VerifyDocument_WithChainValidationDisabled_SucceedsForUntrustedCert()
+    {
+        // Arrange - no TrustedIssuers configured, VerifyCertificateChain disabled
+        var certRequest = new CertificateRequest(
+            "CN=Test Issuer", IssuerSigningKey, HashAlgorithmName.SHA256);
+        using var cert = certRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        var certBytes = cert.RawData;
+
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithIssuerCertificate(certBytes)
+            .WithDeviceKey(CoseKey.FromECDsa(DeviceKey))
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        var options = new MdocVerificationOptions
+        {
+            VerifyDeviceSignature = false,
+            VerifyCertificateChain = false,
+            VerifyValidity = false
+        };
+        var verifier = new MdocVerifier(options);
+
+        // Act
+        var result = verifier.VerifyDocument(document);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.IssuerSignatureValid.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Description

Fixes a bug in `MdocVerifier.VerifyDocument` where the certificate chain validation result was silently lost, causing an invalid issuer certificate to be accepted.

### Root cause

`VerifyIssuerAuth` correctly runs `VerifyCertificateChain` when `VerifyCertificateChain = true` and stores the outcome in `issuerAuthResult.CertificateChainValid`. However, `VerifyDocument` never copied this value to the returned `MdocVerificationResult`. Because `CertificateChainValid` defaults to `true`, callers always saw a passing chain result regardless of the actual validation outcome.

Additionally, a failed chain did not cause `VerifyDocument` to return early — verification continued and ultimately set `IsValid = true` even for an untrusted issuer certificate.

### Fix

In `VerifyDocument`, immediately after the issuer signature check:
- Copy `issuerAuthResult.CertificateChainValid` to `result.CertificateChainValid`
- Return early with the chain error message when `CertificateChainValid` is `false`

### Tests added

Three new test cases in `MdocVerifierTests`:
- `VerifyDocument_WithTrustedIssuerCert_CertificateChainValidIsTrue` — issuer cert in `TrustedIssuers`; expects `CertificateChainValid=true`, `IsValid=true`
- `VerifyDocument_WithUntrustedIssuerCert_CertificateChainValidIsFalseAndIsValidIsFalse` — issuer cert not in `TrustedIssuers`; expects `CertificateChainValid=false`, `IsValid=false`, error propagated
- `VerifyDocument_WithChainValidationDisabled_SucceedsForUntrustedCert` — `VerifyCertificateChain=false`; verification succeeds regardless of cert trust

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass (`dotnet test`)
- [x] Code formatting verified (`dotnet format --verify-no-changes`)
- [x] Commits are signed off (DCO compliance)
