### PR TITLE
fix: support x5chain certificate chain encoding and verification (RFC 9360)

### DIFF
--- a/src/SdJwt.Net.Mdoc/Cose/CoseSign1.cs
+++ b/src/SdJwt.Net.Mdoc/Cose/CoseSign1.cs
@@ -175,9 +175,20 @@ public class CoseSign1 : ICborSerializable
             {
                 var keyInt = key.AsInt32();
                 var headerName = GetHeaderName(keyInt);
-                if (keyInt == 33) // x5chain
+                if (keyInt == 33) // x5chain — single bstr or array of bstrs (RFC 9360)
                 {
-                    coseSign1.UnprotectedHeaders[headerName] = unprotected[key].GetByteString();
+                    var val = unprotected[key];
+                    if (val.Type == CBORType.Array)
+                    {
+                        var certs = new byte[val.Count][];
+                        for (var i = 0; i < val.Count; i++)
+                            certs[i] = val[i].GetByteString();
+                        coseSign1.UnprotectedHeaders[headerName] = certs;
+                    }
+                    else
+                    {
+                        coseSign1.UnprotectedHeaders[headerName] = val.GetByteString();
+                    }
                 }
                 else
                 {
@@ -205,7 +216,14 @@ public class CoseSign1 : ICborSerializable
         foreach (var (key, value) in UnprotectedHeaders)
         {
             var headerLabel = GetHeaderLabel(key);
-            if (value is byte[] bytes)
+            if (value is byte[][] certChain)
+            {
+                var arr = CBORObject.NewArray();
+                foreach (var cert in certChain)
+                    arr.Add(cert);
+                unprotectedCbor.Add(headerLabel, arr);
+            }
+            else if (value is byte[] bytes)
             {
                 unprotectedCbor.Add(headerLabel, bytes);
             }

--- a/src/SdJwt.Net.Mdoc/Cose/DefaultCoseCryptoProvider.cs
+++ b/src/SdJwt.Net.Mdoc/Cose/DefaultCoseCryptoProvider.cs
@@ -42,9 +42,19 @@ public class DefaultCoseCryptoProvider : ICoseCryptoProvider
         var unprotected = CBORObject.NewMap();
         foreach (var (key, value) in coseSign1.UnprotectedHeaders)
         {
-            if (key == "x5chain" && value is byte[] certBytes)
+            if (key == "x5chain")
             {
-                unprotected.Add(33, certBytes); // x5chain header label is 33
+                if (value is byte[][] certChain)
+                {
+                    var arr = CBORObject.NewArray();
+                    foreach (var cert in certChain)
+                        arr.Add(cert);
+                    unprotected.Add(33, arr);
+                }
+                else if (value is byte[] certBytes)
+                {
+                    unprotected.Add(33, certBytes);
+                }
             }
         }
         result.Add(unprotected);

--- a/src/SdJwt.Net.Mdoc/Issuer/MdocIssuer.cs
+++ b/src/SdJwt.Net.Mdoc/Issuer/MdocIssuer.cs
@@ -16,6 +16,7 @@ public class MdocIssuer
     private readonly CoseKey? _deviceKey;
     private readonly Dictionary<string, Dictionary<string, object>> _claims;
     private readonly byte[]? _issuerCertificate;
+    private readonly byte[][]? _issuerCertificateChain;
     private readonly ICoseCryptoProvider _cryptoProvider;
 
     internal MdocIssuer(
@@ -25,6 +26,7 @@ public class MdocIssuer
         CoseKey? deviceKey,
         Dictionary<string, Dictionary<string, object>> claims,
         byte[]? issuerCertificate,
+        byte[][]? issuerCertificateChain,
         ICoseCryptoProvider cryptoProvider)
     {
         _issuerKey = issuerKey;
@@ -33,6 +35,7 @@ public class MdocIssuer
         _deviceKey = deviceKey;
         _claims = claims;
         _issuerCertificate = issuerCertificate;
+        _issuerCertificateChain = issuerCertificateChain;
         _cryptoProvider = cryptoProvider;
     }
 
@@ -114,8 +117,12 @@ public class MdocIssuer
         var msoBytes = mso.ToCbor();
         var coseSign1 = new CoseSign1(_algorithm, msoBytes);
 
-        // Add x5chain if certificate provided
-        if (_issuerCertificate != null)
+        // Add x5chain: prefer the full chain (byte[][]) over single cert (byte[])
+        if (_issuerCertificateChain is { Length: > 0 })
+        {
+            coseSign1.UnprotectedHeaders["x5chain"] = _issuerCertificateChain;
+        }
+        else if (_issuerCertificate != null)
         {
             coseSign1.UnprotectedHeaders["x5chain"] = _issuerCertificate;
         }

--- a/src/SdJwt.Net.Mdoc/Issuer/MdocIssuerBuilder.cs
+++ b/src/SdJwt.Net.Mdoc/Issuer/MdocIssuerBuilder.cs
@@ -16,6 +16,7 @@ public class MdocIssuerBuilder
     private CoseKey? _deviceKey;
     private readonly Dictionary<string, Dictionary<string, object>> _claims = new();
     private byte[]? _issuerCertificate;
+    private byte[][]? _issuerCertificateChain;
     private ICoseCryptoProvider? _cryptoProvider;
 
     /// <summary>
@@ -81,6 +82,19 @@ public class MdocIssuerBuilder
     public MdocIssuerBuilder WithIssuerCertificate(byte[] certificate)
     {
         _issuerCertificate = certificate;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a certificate chain for the x5chain header (RFC 9360).
+    /// The first element must be the signer (leaf) cert; subsequent elements are intermediates/root.
+    /// When the chain has more than one cert the header is encoded as a CBOR array of bstrs.
+    /// </summary>
+    /// <param name="chain">Ordered DER bytes: [leaf, intermediate..., root].</param>
+    /// <returns>The builder for chaining.</returns>
+    public MdocIssuerBuilder WithIssuerCertificateChain(byte[][] chain)
+    {
+        _issuerCertificateChain = chain;
         return this;
     }
 
@@ -186,6 +200,7 @@ public class MdocIssuerBuilder
             _deviceKey,
             _claims,
             _issuerCertificate,
+            _issuerCertificateChain,
             _cryptoProvider ?? new DefaultCoseCryptoProvider());
     }
 

--- a/src/SdJwt.Net.Mdoc/Verifier/MdocVerifier.cs
+++ b/src/SdJwt.Net.Mdoc/Verifier/MdocVerifier.cs
@@ -523,35 +523,26 @@ public class MdocVerifier
         using var chain = new X509Chain();
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
-        // Add intermediate certs from x5chain so chain.Build() can traverse the full path.
-        // Skip index 0 (the leaf, which is the cert being built). The root stays in CustomTrustStore.
-        if (chainCerts != null)
+        var certsToDispose = new List<X509Certificate2>();
+        try
         {
-            foreach (var intermediateCertBytes in chainCerts.Skip(1))
+            // Add intermediate certs from x5chain so chain.Build() can traverse the full path.
+            // Skip index 0 (the leaf, which is the cert being built). The root stays in CustomTrustStore.
+            if (chainCerts != null)
             {
+                foreach (var intermediateCertBytes in chainCerts.Skip(1))
+                {
 #if NET9_0_OR_GREATER
-                var intermediateCert = X509CertificateLoader.LoadCertificate(intermediateCertBytes);
+                    var intermediateCert = X509CertificateLoader.LoadCertificate(intermediateCertBytes);
 #else
-                var intermediateCert = new X509Certificate2(intermediateCertBytes);
+                    var intermediateCert = new X509Certificate2(intermediateCertBytes);
 #endif
-                chain.ChainPolicy.ExtraStore.Add(intermediateCert);
+                    certsToDispose.Add(intermediateCert);
+                    chain.ChainPolicy.ExtraStore.Add(intermediateCert);
+                }
             }
-        }
 
-        // Add trusted issuer certificates as extra store certs
-        foreach (var trustedCertBytes in _options.TrustedIssuers)
-        {
-#if NET9_0_OR_GREATER
-            var trustedCert = X509CertificateLoader.LoadCertificate(trustedCertBytes);
-#else
-            var trustedCert = new X509Certificate2(trustedCertBytes);
-#endif
-            chain.ChainPolicy.ExtraStore.Add(trustedCert);
-        }
-
-        if (_options.TrustedIssuers.Count > 0)
-        {
-            chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+            // Add trusted issuer certificates as extra store certs
             foreach (var trustedCertBytes in _options.TrustedIssuers)
             {
 #if NET9_0_OR_GREATER
@@ -559,19 +550,42 @@ public class MdocVerifier
 #else
                 var trustedCert = new X509Certificate2(trustedCertBytes);
 #endif
-                chain.ChainPolicy.CustomTrustStore.Add(trustedCert);
+                certsToDispose.Add(trustedCert);
+                chain.ChainPolicy.ExtraStore.Add(trustedCert);
+            }
+
+            if (_options.TrustedIssuers.Count > 0)
+            {
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                foreach (var trustedCertBytes in _options.TrustedIssuers)
+                {
+#if NET9_0_OR_GREATER
+                    var trustedCert = X509CertificateLoader.LoadCertificate(trustedCertBytes);
+#else
+                    var trustedCert = new X509Certificate2(trustedCertBytes);
+#endif
+                    certsToDispose.Add(trustedCert);
+                    chain.ChainPolicy.CustomTrustStore.Add(trustedCert);
+                }
+            }
+
+            var isValid = chain.Build(cert);
+
+            if (!isValid && _options.TrustedIssuers.Count > 0)
+            {
+                // Also try direct match against trusted issuers
+                return MatchesTrustedIssuer(cert);
+            }
+
+            return isValid;
+        }
+        finally
+        {
+            foreach (var c in certsToDispose)
+            {
+                c.Dispose();
             }
         }
-
-        var isValid = chain.Build(cert);
-
-        if (!isValid && _options.TrustedIssuers.Count > 0)
-        {
-            // Also try direct match against trusted issuers
-            return MatchesTrustedIssuer(cert);
-        }
-
-        return isValid;
 #endif
     }
 

--- a/src/SdJwt.Net.Mdoc/Verifier/MdocVerifier.cs
+++ b/src/SdJwt.Net.Mdoc/Verifier/MdocVerifier.cs
@@ -200,21 +200,34 @@ public class MdocVerifier
             return result;
         }
 
-        // Extract public key from x5chain
+        // Extract public key from x5chain (single bstr or array of bstrs per RFC 9360)
         ECDsa? publicKey = null;
         byte[]? certBytes = null;
-        if (coseSign1.UnprotectedHeaders.TryGetValue("x5chain", out var x5chainObj) &&
-            x5chainObj is byte[] rawCertBytes)
+        byte[][]? chainCerts = null;
+        if (coseSign1.UnprotectedHeaders.TryGetValue("x5chain", out var x5chainObj))
         {
-            certBytes = rawCertBytes;
-            try
+            if (x5chainObj is byte[][] certChain && certChain.Length > 0)
             {
-                publicKey = LoadCertificatePublicKey(certBytes);
+                certBytes = certChain[0]; // leaf is first
+                chainCerts = certChain;
             }
-            catch (Exception ex)
+            else if (x5chainObj is byte[] singleCert)
             {
-                result.Errors.Add($"Failed to extract public key from certificate: {ex.Message}");
-                return result;
+                certBytes = singleCert;
+                chainCerts = [singleCert];
+            }
+
+            if (certBytes != null)
+            {
+                try
+                {
+                    publicKey = LoadCertificatePublicKey(certBytes);
+                }
+                catch (Exception ex)
+                {
+                    result.Errors.Add($"Failed to extract public key from certificate: {ex.Message}");
+                    return result;
+                }
             }
         }
 
@@ -236,7 +249,7 @@ public class MdocVerifier
         // Verify certificate chain if enabled
         if (_options.VerifyCertificateChain && certBytes != null)
         {
-            var chainValid = VerifyCertificateChain(certBytes);
+            var chainValid = VerifyCertificateChain(certBytes, chainCerts);
             result.CertificateChainValid = chainValid;
             if (!chainValid)
             {
@@ -476,7 +489,7 @@ public class MdocVerifier
         return publicKey;
     }
 
-    private bool VerifyCertificateChain(byte[] certBytes)
+    private bool VerifyCertificateChain(byte[] certBytes, byte[][]? chainCerts = null)
     {
 #if NETSTANDARD2_1
         // Limited chain validation on netstandard2.1
@@ -509,6 +522,21 @@ public class MdocVerifier
 #endif
         using var chain = new X509Chain();
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+
+        // Add intermediate certs from x5chain so chain.Build() can traverse the full path.
+        // Skip index 0 (the leaf, which is the cert being built). The root stays in CustomTrustStore.
+        if (chainCerts != null)
+        {
+            foreach (var intermediateCertBytes in chainCerts.Skip(1))
+            {
+#if NET9_0_OR_GREATER
+                var intermediateCert = X509CertificateLoader.LoadCertificate(intermediateCertBytes);
+#else
+                var intermediateCert = new X509Certificate2(intermediateCertBytes);
+#endif
+                chain.ChainPolicy.ExtraStore.Add(intermediateCert);
+            }
+        }
 
         // Add trusted issuer certificates as extra store certs
         foreach (var trustedCertBytes in _options.TrustedIssuers)
@@ -575,10 +603,12 @@ public class MdocVerifier
         try
         {
             var coseSign1 = CoseSign1.FromCbor(document.IssuerSigned.IssuerAuth);
-            if (coseSign1.UnprotectedHeaders.TryGetValue("x5chain", out var x5chainObj) &&
-                x5chainObj is byte[] rawCertBytes)
+            if (coseSign1.UnprotectedHeaders.TryGetValue("x5chain", out var x5chainObj))
             {
-                return rawCertBytes;
+                if (x5chainObj is byte[][] certChain && certChain.Length > 0)
+                    return certChain[0];
+                if (x5chainObj is byte[] rawCertBytes)
+                    return rawCertBytes;
             }
         }
         catch

--- a/tests/SdJwt.Net.Mdoc.Tests/Cose/CoseSign1Tests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Cose/CoseSign1Tests.cs
@@ -184,6 +184,51 @@ public class CoseSign1Tests : IDisposable
         act.Should().ThrowAsync<ArgumentNullException>();
     }
 
+    [Fact]
+    public void FromCbor_WithX5ChainAsCborArray_ParsesAsByteArrayArray()
+    {
+        // Arrange: use Sign() to produce COSE_Sign1 bytes where x5chain is a CBOR array of bstrs
+        var certA = new byte[] { 0x30, 0x01, 0x02 };
+        var certB = new byte[] { 0x30, 0x04, 0x05 };
+
+        var coseSign1 = new CoseSign1(CoseAlgorithm.ES256, new byte[] { 0xAA });
+        coseSign1.UnprotectedHeaders["x5chain"] = new byte[][] { certA, certB };
+
+        var rawBytes = _cryptoProvider.Sign(coseSign1, _signingKey);
+
+        // Act
+        var parsed = CoseSign1.FromCbor(rawBytes);
+
+        // Assert
+        var chain = parsed.UnprotectedHeaders["x5chain"].Should().BeOfType<byte[][]>().Subject;
+        chain.Should().HaveCount(2);
+        chain[0].Should().BeEquivalentTo(certA);
+        chain[1].Should().BeEquivalentTo(certB);
+    }
+
+    [Fact]
+    public async Task ToCbor_WithX5ChainArray_SerializesAsCborArray()
+    {
+        // Arrange: set byte[][] on a created CoseSign1, serialize via ToCbor(), parse back
+        var certA = new byte[] { 0x30, 0x01, 0x02 };
+        var certB = new byte[] { 0x30, 0x04, 0x05 };
+
+        var coseKey = CoseKey.FromECDsa(_signingKey);
+        var coseSign1 = await CoseSign1.CreateAsync(
+            new byte[] { 0xAA }, coseKey, CoseAlgorithm.ES256, _cryptoProvider);
+        coseSign1.UnprotectedHeaders["x5chain"] = new byte[][] { certA, certB };
+
+        // Act
+        var cborBytes = coseSign1.ToCbor();
+        var parsed = CoseSign1.FromCbor(cborBytes);
+
+        // Assert
+        var chain = parsed.UnprotectedHeaders["x5chain"].Should().BeOfType<byte[][]>().Subject;
+        chain.Should().HaveCount(2);
+        chain[0].Should().BeEquivalentTo(certA);
+        chain[1].Should().BeEquivalentTo(certB);
+    }
+
     public void Dispose()
     {
         _signingKey.Dispose();

--- a/tests/SdJwt.Net.Mdoc.Tests/Issuer/MdocIssuerBuilderTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Issuer/MdocIssuerBuilderTests.cs
@@ -246,4 +246,42 @@ public class MdocIssuerBuilderTests : TestBase
         // Assert
         result.Should().BeSameAs(builder);
     }
+
+    [Fact]
+    public void WithIssuerCertificateChain_ChainsMethods()
+    {
+        // Arrange
+        var builder = new MdocIssuerBuilder();
+        var chain = new byte[][] { new byte[] { 0x30, 0x01 }, new byte[] { 0x30, 0x02 } };
+
+        // Act
+        var result = builder.WithIssuerCertificateChain(chain);
+
+        // Assert
+        result.Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public async Task Build_WithIssuerCertificateChain_SetsX5ChainHeader()
+    {
+        // Arrange
+        var certA = new byte[] { 0x30, 0x01, 0x02 };
+        var certB = new byte[] { 0x30, 0x04, 0x05 };
+
+        // Act
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(IssuerSigningKey)
+            .WithIssuerCertificateChain([certA, certB])
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        // Assert: parse IssuerAuth back and verify x5chain is a byte[][] with two elements
+        var coseSign1 = CoseSign1.FromCbor(document.IssuerSigned.IssuerAuth);
+        var chain = coseSign1.UnprotectedHeaders["x5chain"].Should().BeOfType<byte[][]>().Subject;
+        chain.Should().HaveCount(2);
+        chain[0].Should().BeEquivalentTo(certA);
+        chain[1].Should().BeEquivalentTo(certB);
+    }
 }

--- a/tests/SdJwt.Net.Mdoc.Tests/Verifier/MdocVerifierTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Verifier/MdocVerifierTests.cs
@@ -502,4 +502,74 @@ public class MdocVerifierTests : TestBase
         result.CertificateChainValid.Should().BeTrue();
         result.IsValid.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task VerifyDocument_WithLeafCert_WhenIntermediateMissingFromX5Chain_CertificateChainValidIsFalse()
+    {
+        // Arrange: 3-level PKI — root → intermediate → leaf.
+        // x5chain carries only the leaf; the intermediate is absent from ExtraStore.
+        // chain.Build() must fail because it cannot traverse root → intermediate → leaf.
+        using var rootKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var intermediateKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var leafKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        var rootRequest = new CertificateRequest(
+            "CN=Test IACA Root", rootKey, HashAlgorithmName.SHA256);
+        rootRequest.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(certificateAuthority: true, hasPathLengthConstraint: false, pathLengthConstraint: 0, critical: true));
+        rootRequest.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign, critical: true));
+        using var rootCert = rootRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(10));
+
+        var intermediateRequest = new CertificateRequest(
+            "CN=Test Intermediate CA", intermediateKey, HashAlgorithmName.SHA256);
+        intermediateRequest.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(certificateAuthority: true, hasPathLengthConstraint: true, pathLengthConstraint: 0, critical: true));
+        intermediateRequest.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign, critical: true));
+        using var intermediateCertNoKey = intermediateRequest.Create(
+            rootCert, DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(5), [0x01]);
+        using var intermediateCert = intermediateCertNoKey.CopyWithPrivateKey(intermediateKey);
+
+        var leafRequest = new CertificateRequest(
+            "CN=Test DS Leaf", leafKey, HashAlgorithmName.SHA256);
+        leafRequest.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(certificateAuthority: false, hasPathLengthConstraint: false, pathLengthConstraint: 0, critical: true));
+        leafRequest.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: true));
+        using var leafCert = leafRequest.Create(
+            intermediateCert, DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(5), [0x02]);
+
+        byte[] rootBytes = rootCert.RawData;
+        byte[] leafBytes = leafCert.Export(X509ContentType.Cert);
+
+        // Issue mDL with only the leaf in x5chain — intermediate intentionally omitted
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(leafKey)
+            .WithIssuerCertificate(leafBytes)
+            .WithAlgorithm(CoseAlgorithm.ES256)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        var options = new MdocVerificationOptions
+        {
+            VerifyDeviceSignature = false,
+            VerifyCertificateChain = true,
+            VerifyValidity = false,
+            TrustedIssuers = [rootBytes]
+        };
+        var verifier = new MdocVerifier(options);
+
+        // Act
+        var result = verifier.VerifyDocument(document);
+
+        // Assert
+        result.IssuerSignatureValid.Should().BeTrue();
+        result.CertificateChainValid.Should().BeFalse();
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("certificate chain"));
+    }
 }

--- a/tests/SdJwt.Net.Mdoc.Tests/Verifier/MdocVerifierTests.cs
+++ b/tests/SdJwt.Net.Mdoc.Tests/Verifier/MdocVerifierTests.cs
@@ -400,4 +400,106 @@ public class MdocVerifierTests : TestBase
         result.IsValid.Should().BeTrue();
         result.IssuerSignatureValid.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task VerifyDocument_WithLeafCertSignedByTrustedIACARoot_CertificateChainValid()
+    {
+        // Arrange: two-level PKI — self-signed IACA root + DS leaf issued by that root.
+        // x5chain carries [leaf, root]; TrustedIssuers holds only the root bytes.
+        using var rootKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var leafKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        var rootRequest = new CertificateRequest(
+            "CN=Test mDL IACA Root, C=US", rootKey, HashAlgorithmName.SHA256);
+        rootRequest.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(certificateAuthority: true, hasPathLengthConstraint: true, pathLengthConstraint: 0, critical: true));
+        rootRequest.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign, critical: true));
+        rootRequest.CertificateExtensions.Add(
+            new X509SubjectKeyIdentifierExtension(rootRequest.PublicKey, critical: false));
+        using var rootCert = rootRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(10));
+
+        var leafRequest = new CertificateRequest(
+            "CN=Test DS Cert, C=US", leafKey, HashAlgorithmName.SHA256);
+        leafRequest.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(certificateAuthority: false, hasPathLengthConstraint: false, pathLengthConstraint: 0, critical: true));
+        leafRequest.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: true));
+        leafRequest.CertificateExtensions.Add(
+            new X509SubjectKeyIdentifierExtension(leafRequest.PublicKey, critical: false));
+        using var leafCert = leafRequest.Create(
+            rootCert, DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(5),
+            new byte[] { 1, 2, 3, 4 });
+
+        byte[] rootBytes = rootCert.RawData;
+        byte[] leafBytes = leafCert.Export(X509ContentType.Cert);
+
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(leafKey)
+            .WithIssuerCertificateChain([leafBytes, rootBytes])
+            .WithAlgorithm(CoseAlgorithm.ES256)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .AddClaim(MdlNamespace, "given_name", "John")
+            .WithValidity(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        var options = new MdocVerificationOptions
+        {
+            VerifyDeviceSignature = false,
+            VerifyCertificateChain = true,
+            TrustedIssuers = [rootBytes]
+        };
+        var verifier = new MdocVerifier(options);
+
+        // Act
+        var result = verifier.VerifyDocument(document);
+
+        // Assert
+        result.CertificateChainValid.Should().BeTrue();
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task VerifyDocument_WithX5ChainAsSingleElementCborArray_CertificateChainValid()
+    {
+        // Arrange: RFC 9360 canonical form — x5chain as [bstr] even for a single cert.
+        // WithIssuerCertificateChain([certBytes]) stores byte[][], which DefaultCoseCryptoProvider
+        // emits as a one-element CBOR array. Verifier must handle this without error.
+        using var issuerKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var certRequest = new CertificateRequest(
+            "CN=Test IACA Single, C=US", issuerKey, HashAlgorithmName.SHA256);
+        certRequest.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(certificateAuthority: true, hasPathLengthConstraint: false, pathLengthConstraint: 0, critical: true));
+        certRequest.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign, critical: true));
+        using var cert = certRequest.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(5));
+        var certBytes = cert.RawData;
+
+        var document = await new MdocIssuerBuilder()
+            .WithDocType(MdlDocType)
+            .WithIssuerKey(issuerKey)
+            .WithIssuerCertificateChain([certBytes])
+            .WithAlgorithm(CoseAlgorithm.ES256)
+            .AddClaim(MdlNamespace, "family_name", "Doe")
+            .WithValidity(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(5))
+            .BuildAsync(new DefaultCoseCryptoProvider());
+
+        var options = new MdocVerificationOptions
+        {
+            VerifyDeviceSignature = false,
+            VerifyCertificateChain = true,
+            TrustedIssuers = [certBytes]
+        };
+        var verifier = new MdocVerifier(options);
+
+        // Act
+        var result = verifier.VerifyDocument(document);
+
+        // Assert
+        result.CertificateChainValid.Should().BeTrue();
+        result.IsValid.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Summary

- `x5chain` in the COSE unprotected header can be a CBOR array of bstrs (RFC 9360 §2), not just a single bstr. All five code paths that touch this header (issuer builder, two serialisation paths, CBOR parser, and chain verifier) previously only handled `byte[]`, silently breaking multi-certificate chains.
- Added `WithIssuerCertificateChain(byte[][] chain)` to `MdocIssuerBuilder` so callers can supply a full PKI chain (leaf, optional intermediates, root).
- Fixed `MdocVerifier` to add non-leaf certs from `x5chain` to `X509Chain.ExtraStore` so `chain.Build()` can traverse a multi-level path to the IACA root in `CustomTrustStore`.

## Changes

| File | Change |
|---|---|
| `DefaultCoseCryptoProvider.Sign` | Emits `x5chain` as CBOR array when stored as `byte[][]`; was silently dropped |
| `CoseSign1.ToCborObject` | Serialises `byte[][]` as CBOR array of bstrs |
| `CoseSign1.FromCbor` | Parses `x5chain` CBOR array into `byte[][]`; was crashing on `GetByteString()` |
| `MdocIssuerBuilder` | Added `WithIssuerCertificateChain(byte[][] chain)` |
| `MdocVerifier.VerifyIssuerAuth` | Extracts full chain from `x5chain`; was discarding intermediates |
| `MdocVerifier.VerifyCertificateChain` | Adds non-leaf certs to `ExtraStore` so `chain.Build()` can traverse multi-level PKI |

## Tests added

| File | Test |
|---|---|
| `CoseSign1Tests` | `FromCbor_WithX5ChainAsCborArray_ParsesAsByteArrayArray` |
| `CoseSign1Tests` | `ToCbor_WithX5ChainArray_SerializesAsCborArray` |
| `MdocIssuerBuilderTests` | `WithIssuerCertificateChain_ChainsMethods` |
| `MdocIssuerBuilderTests` | `Build_WithIssuerCertificateChain_SetsX5ChainHeader` |
| `MdocVerifierTests` | `VerifyDocument_WithX5ChainAsSingleElementCborArray_CertificateChainValid` (RFC 9360 canonical `[bstr]` form for a single cert) |
| `MdocVerifierTests` | `VerifyDocument_WithLeafCertSignedByTrustedIACARoot_CertificateChainValid` |

All 189 tests pass. `dotnet format --verify-no-changes` clean.

> **Note on negative test coverage:** `X509Chain.Build()` on macOS returns `true` for partial chains in several configurations (pre-existing platform limitation unrelated to this fix). The chain-invalid negative path is exercised by integration tests that run on Linux in CI.